### PR TITLE
fix: don't jump to the inexistent virtual desktop

### DIFF
--- a/Source/VirtualDesktopAPI/Implementation/VirtualDesktopWin10.cs
+++ b/Source/VirtualDesktopAPI/Implementation/VirtualDesktopWin10.cs
@@ -39,6 +39,9 @@ namespace WindowsVirtualDesktopHelper.VirtualDesktopAPI.Implementation {
 
 		public void SwitchToDesktop(int number) {
 			var desktop = DesktopManager.GetDesktopAtIndex(number);
+
+			if (desktop == null) return;
+
 			DesktopManager.VirtualDesktopManagerInternal.SwitchDesktop(desktop);
 		}
 

--- a/Source/VirtualDesktopAPI/Implementation/VirtualDesktopWin11_21H2.cs
+++ b/Source/VirtualDesktopAPI/Implementation/VirtualDesktopWin11_21H2.cs
@@ -49,6 +49,9 @@ namespace WindowsVirtualDesktopHelper.VirtualDesktopAPI.Implementation {
 
 		public void SwitchToDesktop(int number) {
 			var desktop = DesktopManager.GetDesktopAtIndex(number);
+
+			if (desktop == null) return;
+
 			DesktopManager.VirtualDesktopManagerInternal.SwitchDesktop(IntPtr.Zero, desktop);
 		}
 

--- a/Source/VirtualDesktopAPI/Implementation/VirtualDesktopWin11_22H2.cs
+++ b/Source/VirtualDesktopAPI/Implementation/VirtualDesktopWin11_22H2.cs
@@ -49,6 +49,9 @@ namespace WindowsVirtualDesktopHelper.VirtualDesktopAPI.Implementation {
 
 		public void SwitchToDesktop(int number) {
 			var desktop = DesktopManager.GetDesktopAtIndex(number);
+
+			if (desktop == null) return;
+
 			DesktopManager.VirtualDesktopManagerInternal.SwitchDesktop(IntPtr.Zero, desktop);
 		}
 

--- a/Source/VirtualDesktopAPI/Implementation/VirtualDesktopWin11_23H2.cs
+++ b/Source/VirtualDesktopAPI/Implementation/VirtualDesktopWin11_23H2.cs
@@ -50,6 +50,9 @@ namespace WindowsVirtualDesktopHelper.VirtualDesktopAPI.Implementation {
 
 		public void SwitchToDesktop(int number) {
 			var desktop = DesktopManager.GetDesktopAtIndex(number);
+
+			if (desktop == null) return;
+
 			DesktopManager.VirtualDesktopManagerInternal.SwitchDesktop(desktop);
 		}
 

--- a/Source/VirtualDesktopAPI/Implementation/VirtualDesktopWin11_Insider.cs
+++ b/Source/VirtualDesktopAPI/Implementation/VirtualDesktopWin11_Insider.cs
@@ -44,6 +44,9 @@ namespace WindowsVirtualDesktopHelper.VirtualDesktopAPI.Implementation {
 
 		public void SwitchToDesktop(int number) {
 			var desktop = DesktopManager.GetDesktop(number);
+
+			if (desktop == null) return;
+
 			DesktopManager.VirtualDesktopManagerInternal.SwitchDesktop(IntPtr.Zero, desktop);
 		}
 

--- a/Source/VirtualDesktopAPI/Implementation/VirtualDesktopWin11_InsiderCanary.cs
+++ b/Source/VirtualDesktopAPI/Implementation/VirtualDesktopWin11_InsiderCanary.cs
@@ -48,6 +48,9 @@ namespace WindowsVirtualDesktopHelper.VirtualDesktopAPI.Implementation {
 
 		public void SwitchToDesktop(int number) {
 			var desktop = DesktopManager.GetDesktop(number);
+
+			if (desktop == null) return;
+
 			DesktopManager.VirtualDesktopManagerInternal.SwitchDesktop(desktop);
 
 		}


### PR DESCRIPTION
`VirtualDesktopManager.SwitchToDesktop()` checks if `desktop` is `null` before calling `VirtualDesktopManagerInternal.SwitchDesktop(desktop)`

closes #121