### PR TITLE
Patch win11 23 h2 2921

### DIFF
--- a/Source/App/App.cs
+++ b/Source/App/App.cs
@@ -18,6 +18,7 @@ namespace WindowsVirtualDesktopHelper {
 		public SettingsForm SettingsForm;
 		public string CurrentSystemThemeName = null;
 		public List<string> FGWindowHistory = new List<string>(); // needed to detect if Task View was open
+		public IntPtr LastForegroundhWnd = IntPtr.Zero;
 		KeyboardHook KeyboardHooksJumpToDesktop = null;
 
 		public static string DetectedVDImplementation = null;
@@ -173,6 +174,9 @@ namespace WindowsVirtualDesktopHelper {
 					var maxHistory = 20;
 					if (FGWindowHistory.Count > maxHistory) {
 						FGWindowHistory.RemoveRange(0, FGWindowHistory.Count - maxHistory);
+					}
+					if (LastForegroundhWnd == IntPtr.Zero) {
+						LastForegroundhWnd = Util.OS.GetFolderViewHandle();
 					}
 					System.Threading.Thread.Sleep(20);
 				} catch (Exception e) {

--- a/Source/Forms/SettingsForm.Designer.cs
+++ b/Source/Forms/SettingsForm.Designer.cs
@@ -92,34 +92,34 @@ namespace WindowsVirtualDesktopHelper {
             this.toolStripMenuItemSettings,
             this.toolStripMenuItemExit});
             this.contextMenuStrip1.Name = "contextMenuStrip1";
-            this.contextMenuStrip1.Size = new System.Drawing.Size(271, 186);
+            this.contextMenuStrip1.Size = new System.Drawing.Size(117, 92);
             this.contextMenuStrip1.ItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.contextMenuStrip1_ItemClicked);
             // 
             // toolStripMenuItemAbout
             // 
             this.toolStripMenuItemAbout.Name = "toolStripMenuItemAbout";
-            this.toolStripMenuItemAbout.Size = new System.Drawing.Size(270, 36);
+            this.toolStripMenuItemAbout.Size = new System.Drawing.Size(116, 22);
             this.toolStripMenuItemAbout.Tag = "about";
             this.toolStripMenuItemAbout.Text = "About";
             // 
             // toolStripMenuItemDonate
             // 
             this.toolStripMenuItemDonate.Name = "toolStripMenuItemDonate";
-            this.toolStripMenuItemDonate.Size = new System.Drawing.Size(270, 36);
+            this.toolStripMenuItemDonate.Size = new System.Drawing.Size(116, 22);
             this.toolStripMenuItemDonate.Tag = "donate";
             this.toolStripMenuItemDonate.Text = "Donate";
             // 
             // toolStripMenuItemSettings
             // 
             this.toolStripMenuItemSettings.Name = "toolStripMenuItemSettings";
-            this.toolStripMenuItemSettings.Size = new System.Drawing.Size(270, 36);
+            this.toolStripMenuItemSettings.Size = new System.Drawing.Size(116, 22);
             this.toolStripMenuItemSettings.Tag = "settings";
             this.toolStripMenuItemSettings.Text = "Settings";
             // 
             // toolStripMenuItemExit
             // 
             this.toolStripMenuItemExit.Name = "toolStripMenuItemExit";
-            this.toolStripMenuItemExit.Size = new System.Drawing.Size(270, 36);
+            this.toolStripMenuItemExit.Size = new System.Drawing.Size(116, 22);
             this.toolStripMenuItemExit.Tag = "exit";
             this.toolStripMenuItemExit.Text = "Exit";
             // 
@@ -127,23 +127,20 @@ namespace WindowsVirtualDesktopHelper {
             // 
             this.notifyIconPrev.Icon = ((System.Drawing.Icon)(resources.GetObject("notifyIconPrev.Icon")));
             this.notifyIconPrev.Text = "Previous Desktop";
-            this.notifyIconPrev.Visible = true;
             this.notifyIconPrev.Click += new System.EventHandler(this.notifyIconPrev_Click);
             // 
             // notifyIconNext
             // 
             this.notifyIconNext.Icon = ((System.Drawing.Icon)(resources.GetObject("notifyIconNext.Icon")));
             this.notifyIconNext.Text = "Next Desktop";
-            this.notifyIconNext.Visible = true;
             this.notifyIconNext.Click += new System.EventHandler(this.notifyIconNext_Click);
             // 
             // checkBoxShowPrevNextIcons
             // 
             this.checkBoxShowPrevNextIcons.AutoSize = true;
-            this.checkBoxShowPrevNextIcons.Location = new System.Drawing.Point(28, 35);
-            this.checkBoxShowPrevNextIcons.Margin = new System.Windows.Forms.Padding(6);
+            this.checkBoxShowPrevNextIcons.Location = new System.Drawing.Point(15, 19);
             this.checkBoxShowPrevNextIcons.Name = "checkBoxShowPrevNextIcons";
-            this.checkBoxShowPrevNextIcons.Size = new System.Drawing.Size(409, 29);
+            this.checkBoxShowPrevNextIcons.Size = new System.Drawing.Size(232, 17);
             this.checkBoxShowPrevNextIcons.TabIndex = 1;
             this.checkBoxShowPrevNextIcons.Text = "Show Previous / Next Desktop in Icon Tray";
             this.checkBoxShowPrevNextIcons.UseVisualStyleBackColor = true;
@@ -163,11 +160,9 @@ namespace WindowsVirtualDesktopHelper {
             this.groupBox1.Controls.Add(this.checkBoxOverlayAnimate);
             this.groupBox1.Controls.Add(this.checkBoxShowOverlay);
             this.groupBox1.Controls.Add(this.checkBoxShowPrevNextIcons);
-            this.groupBox1.Location = new System.Drawing.Point(22, 22);
-            this.groupBox1.Margin = new System.Windows.Forms.Padding(6);
+            this.groupBox1.Location = new System.Drawing.Point(12, 12);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Padding = new System.Windows.Forms.Padding(6);
-            this.groupBox1.Size = new System.Drawing.Size(757, 567);
+            this.groupBox1.Size = new System.Drawing.Size(413, 307);
             this.groupBox1.TabIndex = 2;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Features";
@@ -178,19 +173,17 @@ namespace WindowsVirtualDesktopHelper {
             this.panel3.Controls.Add(this.radioButtonUseHotKeysToJumpToDesktopAltShift);
             this.panel3.Controls.Add(this.radioButtonUseHotKeysToJumpToDesktopCtrlAlt);
             this.panel3.Controls.Add(this.radioButtonUseHotKeysToJumpToDesktopCtrl);
-            this.panel3.Location = new System.Drawing.Point(73, 509);
-            this.panel3.Margin = new System.Windows.Forms.Padding(6);
+            this.panel3.Location = new System.Drawing.Point(40, 276);
             this.panel3.Name = "panel3";
-            this.panel3.Size = new System.Drawing.Size(660, 46);
+            this.panel3.Size = new System.Drawing.Size(360, 25);
             this.panel3.TabIndex = 20;
             // 
             // radioButtonUseHotKeysToJumpToDesktopAlt
             // 
             this.radioButtonUseHotKeysToJumpToDesktopAlt.AutoSize = true;
-            this.radioButtonUseHotKeysToJumpToDesktopAlt.Location = new System.Drawing.Point(9, 9);
-            this.radioButtonUseHotKeysToJumpToDesktopAlt.Margin = new System.Windows.Forms.Padding(6);
+            this.radioButtonUseHotKeysToJumpToDesktopAlt.Location = new System.Drawing.Point(5, 5);
             this.radioButtonUseHotKeysToJumpToDesktopAlt.Name = "radioButtonUseHotKeysToJumpToDesktopAlt";
-            this.radioButtonUseHotKeysToJumpToDesktopAlt.Size = new System.Drawing.Size(83, 29);
+            this.radioButtonUseHotKeysToJumpToDesktopAlt.Size = new System.Drawing.Size(50, 17);
             this.radioButtonUseHotKeysToJumpToDesktopAlt.TabIndex = 9;
             this.radioButtonUseHotKeysToJumpToDesktopAlt.TabStop = true;
             this.radioButtonUseHotKeysToJumpToDesktopAlt.Text = "Alt+#";
@@ -200,10 +193,9 @@ namespace WindowsVirtualDesktopHelper {
             // radioButtonUseHotKeysToJumpToDesktopAltShift
             // 
             this.radioButtonUseHotKeysToJumpToDesktopAltShift.AutoSize = true;
-            this.radioButtonUseHotKeysToJumpToDesktopAltShift.Location = new System.Drawing.Point(343, 9);
-            this.radioButtonUseHotKeysToJumpToDesktopAltShift.Margin = new System.Windows.Forms.Padding(6);
+            this.radioButtonUseHotKeysToJumpToDesktopAltShift.Location = new System.Drawing.Point(187, 5);
             this.radioButtonUseHotKeysToJumpToDesktopAltShift.Name = "radioButtonUseHotKeysToJumpToDesktopAltShift";
-            this.radioButtonUseHotKeysToJumpToDesktopAltShift.Size = new System.Drawing.Size(134, 29);
+            this.radioButtonUseHotKeysToJumpToDesktopAltShift.Size = new System.Drawing.Size(77, 17);
             this.radioButtonUseHotKeysToJumpToDesktopAltShift.TabIndex = 8;
             this.radioButtonUseHotKeysToJumpToDesktopAltShift.TabStop = true;
             this.radioButtonUseHotKeysToJumpToDesktopAltShift.Text = "Alt+Shift+#";
@@ -213,10 +205,9 @@ namespace WindowsVirtualDesktopHelper {
             // radioButtonUseHotKeysToJumpToDesktopCtrlAlt
             // 
             this.radioButtonUseHotKeysToJumpToDesktopCtrlAlt.AutoSize = true;
-            this.radioButtonUseHotKeysToJumpToDesktopCtrlAlt.Location = new System.Drawing.Point(206, 9);
-            this.radioButtonUseHotKeysToJumpToDesktopCtrlAlt.Margin = new System.Windows.Forms.Padding(6);
+            this.radioButtonUseHotKeysToJumpToDesktopCtrlAlt.Location = new System.Drawing.Point(112, 5);
             this.radioButtonUseHotKeysToJumpToDesktopCtrlAlt.Name = "radioButtonUseHotKeysToJumpToDesktopCtrlAlt";
-            this.radioButtonUseHotKeysToJumpToDesktopCtrlAlt.Size = new System.Drawing.Size(125, 29);
+            this.radioButtonUseHotKeysToJumpToDesktopCtrlAlt.Size = new System.Drawing.Size(71, 17);
             this.radioButtonUseHotKeysToJumpToDesktopCtrlAlt.TabIndex = 7;
             this.radioButtonUseHotKeysToJumpToDesktopCtrlAlt.TabStop = true;
             this.radioButtonUseHotKeysToJumpToDesktopCtrlAlt.Text = "Ctrl+Alt+#";
@@ -226,10 +217,9 @@ namespace WindowsVirtualDesktopHelper {
             // radioButtonUseHotKeysToJumpToDesktopCtrl
             // 
             this.radioButtonUseHotKeysToJumpToDesktopCtrl.AutoSize = true;
-            this.radioButtonUseHotKeysToJumpToDesktopCtrl.Location = new System.Drawing.Point(104, 9);
-            this.radioButtonUseHotKeysToJumpToDesktopCtrl.Margin = new System.Windows.Forms.Padding(6);
+            this.radioButtonUseHotKeysToJumpToDesktopCtrl.Location = new System.Drawing.Point(57, 5);
             this.radioButtonUseHotKeysToJumpToDesktopCtrl.Name = "radioButtonUseHotKeysToJumpToDesktopCtrl";
-            this.radioButtonUseHotKeysToJumpToDesktopCtrl.Size = new System.Drawing.Size(90, 29);
+            this.radioButtonUseHotKeysToJumpToDesktopCtrl.Size = new System.Drawing.Size(53, 17);
             this.radioButtonUseHotKeysToJumpToDesktopCtrl.TabIndex = 6;
             this.radioButtonUseHotKeysToJumpToDesktopCtrl.TabStop = true;
             this.radioButtonUseHotKeysToJumpToDesktopCtrl.Text = "Ctrl+#";
@@ -239,10 +229,9 @@ namespace WindowsVirtualDesktopHelper {
             // checkBoxUseHotKeysToJumpToDesktop
             // 
             this.checkBoxUseHotKeysToJumpToDesktop.AutoSize = true;
-            this.checkBoxUseHotKeysToJumpToDesktop.Location = new System.Drawing.Point(28, 482);
-            this.checkBoxUseHotKeysToJumpToDesktop.Margin = new System.Windows.Forms.Padding(6);
+            this.checkBoxUseHotKeysToJumpToDesktop.Location = new System.Drawing.Point(15, 261);
             this.checkBoxUseHotKeysToJumpToDesktop.Name = "checkBoxUseHotKeysToJumpToDesktop";
-            this.checkBoxUseHotKeysToJumpToDesktop.Size = new System.Drawing.Size(331, 29);
+            this.checkBoxUseHotKeysToJumpToDesktop.Size = new System.Drawing.Size(186, 17);
             this.checkBoxUseHotKeysToJumpToDesktop.TabIndex = 23;
             this.checkBoxUseHotKeysToJumpToDesktop.Text = "Use Hot Keys to Jump to Desktop";
             this.checkBoxUseHotKeysToJumpToDesktop.UseVisualStyleBackColor = true;
@@ -251,10 +240,9 @@ namespace WindowsVirtualDesktopHelper {
             // checkBoxOverlayShowOnAllMonitors
             // 
             this.checkBoxOverlayShowOnAllMonitors.AutoSize = true;
-            this.checkBoxOverlayShowOnAllMonitors.Location = new System.Drawing.Point(78, 245);
-            this.checkBoxOverlayShowOnAllMonitors.Margin = new System.Windows.Forms.Padding(6);
+            this.checkBoxOverlayShowOnAllMonitors.Location = new System.Drawing.Point(43, 133);
             this.checkBoxOverlayShowOnAllMonitors.Name = "checkBoxOverlayShowOnAllMonitors";
-            this.checkBoxOverlayShowOnAllMonitors.Size = new System.Drawing.Size(219, 29);
+            this.checkBoxOverlayShowOnAllMonitors.Size = new System.Drawing.Size(124, 17);
             this.checkBoxOverlayShowOnAllMonitors.TabIndex = 22;
             this.checkBoxOverlayShowOnAllMonitors.Text = "Show on all Monitors";
             this.checkBoxOverlayShowOnAllMonitors.UseVisualStyleBackColor = true;
@@ -263,10 +251,9 @@ namespace WindowsVirtualDesktopHelper {
             // checkBoxShowDesktopNameInitial
             // 
             this.checkBoxShowDesktopNameInitial.AutoSize = true;
-            this.checkBoxShowDesktopNameInitial.Location = new System.Drawing.Point(28, 441);
-            this.checkBoxShowDesktopNameInitial.Margin = new System.Windows.Forms.Padding(6);
+            this.checkBoxShowDesktopNameInitial.Location = new System.Drawing.Point(15, 239);
             this.checkBoxShowDesktopNameInitial.Name = "checkBoxShowDesktopNameInitial";
-            this.checkBoxShowDesktopNameInitial.Size = new System.Drawing.Size(378, 29);
+            this.checkBoxShowDesktopNameInitial.Size = new System.Drawing.Size(213, 17);
             this.checkBoxShowDesktopNameInitial.TabIndex = 21;
             this.checkBoxShowDesktopNameInitial.Text = "Show Desktop Name Initial in Icon Tray";
             this.checkBoxShowDesktopNameInitial.UseVisualStyleBackColor = true;
@@ -275,10 +262,9 @@ namespace WindowsVirtualDesktopHelper {
             // checkBoxClickDesktopNumberTaskView
             // 
             this.checkBoxClickDesktopNumberTaskView.AutoSize = true;
-            this.checkBoxClickDesktopNumberTaskView.Location = new System.Drawing.Point(28, 400);
-            this.checkBoxClickDesktopNumberTaskView.Margin = new System.Windows.Forms.Padding(6);
+            this.checkBoxClickDesktopNumberTaskView.Location = new System.Drawing.Point(15, 217);
             this.checkBoxClickDesktopNumberTaskView.Name = "checkBoxClickDesktopNumberTaskView";
-            this.checkBoxClickDesktopNumberTaskView.Size = new System.Drawing.Size(521, 29);
+            this.checkBoxClickDesktopNumberTaskView.Size = new System.Drawing.Size(290, 17);
             this.checkBoxClickDesktopNumberTaskView.TabIndex = 20;
             this.checkBoxClickDesktopNumberTaskView.Text = "Clicking Desktop Number in Icon Tray opens Task View";
             this.checkBoxClickDesktopNumberTaskView.UseVisualStyleBackColor = true;
@@ -290,19 +276,17 @@ namespace WindowsVirtualDesktopHelper {
             this.panel2.Controls.Add(this.radioButtonOverlayLongDuration);
             this.panel2.Controls.Add(this.radioButtonOverlayMediumDuration);
             this.panel2.Controls.Add(this.radioButtonOverlayShortDuration);
-            this.panel2.Location = new System.Drawing.Point(73, 114);
-            this.panel2.Margin = new System.Windows.Forms.Padding(6);
+            this.panel2.Location = new System.Drawing.Point(40, 62);
             this.panel2.Name = "panel2";
-            this.panel2.Size = new System.Drawing.Size(660, 46);
+            this.panel2.Size = new System.Drawing.Size(360, 25);
             this.panel2.TabIndex = 19;
             // 
             // radioButtonOverlayMicroDuration
             // 
             this.radioButtonOverlayMicroDuration.AutoSize = true;
-            this.radioButtonOverlayMicroDuration.Location = new System.Drawing.Point(9, 9);
-            this.radioButtonOverlayMicroDuration.Margin = new System.Windows.Forms.Padding(6);
+            this.radioButtonOverlayMicroDuration.Location = new System.Drawing.Point(5, 5);
             this.radioButtonOverlayMicroDuration.Name = "radioButtonOverlayMicroDuration";
-            this.radioButtonOverlayMicroDuration.Size = new System.Drawing.Size(96, 29);
+            this.radioButtonOverlayMicroDuration.Size = new System.Drawing.Size(56, 17);
             this.radioButtonOverlayMicroDuration.TabIndex = 9;
             this.radioButtonOverlayMicroDuration.TabStop = true;
             this.radioButtonOverlayMicroDuration.Text = "500ms";
@@ -311,10 +295,9 @@ namespace WindowsVirtualDesktopHelper {
             // radioButtonOverlayLongDuration
             // 
             this.radioButtonOverlayLongDuration.AutoSize = true;
-            this.radioButtonOverlayLongDuration.Location = new System.Drawing.Point(372, 9);
-            this.radioButtonOverlayLongDuration.Margin = new System.Windows.Forms.Padding(6);
+            this.radioButtonOverlayLongDuration.Location = new System.Drawing.Point(203, 5);
             this.radioButtonOverlayLongDuration.Name = "radioButtonOverlayLongDuration";
-            this.radioButtonOverlayLongDuration.Size = new System.Drawing.Size(107, 29);
+            this.radioButtonOverlayLongDuration.Size = new System.Drawing.Size(62, 17);
             this.radioButtonOverlayLongDuration.TabIndex = 8;
             this.radioButtonOverlayLongDuration.TabStop = true;
             this.radioButtonOverlayLongDuration.Text = "3000ms";
@@ -323,10 +306,9 @@ namespace WindowsVirtualDesktopHelper {
             // radioButtonOverlayMediumDuration
             // 
             this.radioButtonOverlayMediumDuration.AutoSize = true;
-            this.radioButtonOverlayMediumDuration.Location = new System.Drawing.Point(251, 9);
-            this.radioButtonOverlayMediumDuration.Margin = new System.Windows.Forms.Padding(6);
+            this.radioButtonOverlayMediumDuration.Location = new System.Drawing.Point(137, 5);
             this.radioButtonOverlayMediumDuration.Name = "radioButtonOverlayMediumDuration";
-            this.radioButtonOverlayMediumDuration.Size = new System.Drawing.Size(107, 29);
+            this.radioButtonOverlayMediumDuration.Size = new System.Drawing.Size(62, 17);
             this.radioButtonOverlayMediumDuration.TabIndex = 7;
             this.radioButtonOverlayMediumDuration.TabStop = true;
             this.radioButtonOverlayMediumDuration.Text = "2000ms";
@@ -335,10 +317,9 @@ namespace WindowsVirtualDesktopHelper {
             // radioButtonOverlayShortDuration
             // 
             this.radioButtonOverlayShortDuration.AutoSize = true;
-            this.radioButtonOverlayShortDuration.Location = new System.Drawing.Point(127, 9);
-            this.radioButtonOverlayShortDuration.Margin = new System.Windows.Forms.Padding(6);
+            this.radioButtonOverlayShortDuration.Location = new System.Drawing.Point(69, 5);
             this.radioButtonOverlayShortDuration.Name = "radioButtonOverlayShortDuration";
-            this.radioButtonOverlayShortDuration.Size = new System.Drawing.Size(107, 29);
+            this.radioButtonOverlayShortDuration.Size = new System.Drawing.Size(62, 17);
             this.radioButtonOverlayShortDuration.TabIndex = 6;
             this.radioButtonOverlayShortDuration.TabStop = true;
             this.radioButtonOverlayShortDuration.Text = "1000ms";
@@ -355,19 +336,17 @@ namespace WindowsVirtualDesktopHelper {
             this.panel1.Controls.Add(this.radioButtonPositionTopRight);
             this.panel1.Controls.Add(this.radioButtonPositionTopCenter);
             this.panel1.Controls.Add(this.radioButtonPositionTopLeft);
-            this.panel1.Location = new System.Drawing.Point(160, 280);
-            this.panel1.Margin = new System.Windows.Forms.Padding(6);
+            this.panel1.Location = new System.Drawing.Point(87, 152);
             this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(114, 109);
+            this.panel1.Size = new System.Drawing.Size(62, 59);
             this.panel1.TabIndex = 18;
             // 
             // radioButtonPositionBottomRight
             // 
             this.radioButtonPositionBottomRight.AutoSize = true;
-            this.radioButtonPositionBottomRight.Location = new System.Drawing.Point(79, 76);
-            this.radioButtonPositionBottomRight.Margin = new System.Windows.Forms.Padding(6);
+            this.radioButtonPositionBottomRight.Location = new System.Drawing.Point(43, 41);
             this.radioButtonPositionBottomRight.Name = "radioButtonPositionBottomRight";
-            this.radioButtonPositionBottomRight.Size = new System.Drawing.Size(21, 20);
+            this.radioButtonPositionBottomRight.Size = new System.Drawing.Size(14, 13);
             this.radioButtonPositionBottomRight.TabIndex = 26;
             this.radioButtonPositionBottomRight.TabStop = true;
             this.radioButtonPositionBottomRight.UseVisualStyleBackColor = true;
@@ -375,10 +354,9 @@ namespace WindowsVirtualDesktopHelper {
             // radioButtonPositionBottomCenter
             // 
             this.radioButtonPositionBottomCenter.AutoSize = true;
-            this.radioButtonPositionBottomCenter.Location = new System.Drawing.Point(42, 76);
-            this.radioButtonPositionBottomCenter.Margin = new System.Windows.Forms.Padding(6);
+            this.radioButtonPositionBottomCenter.Location = new System.Drawing.Point(23, 41);
             this.radioButtonPositionBottomCenter.Name = "radioButtonPositionBottomCenter";
-            this.radioButtonPositionBottomCenter.Size = new System.Drawing.Size(21, 20);
+            this.radioButtonPositionBottomCenter.Size = new System.Drawing.Size(14, 13);
             this.radioButtonPositionBottomCenter.TabIndex = 25;
             this.radioButtonPositionBottomCenter.TabStop = true;
             this.radioButtonPositionBottomCenter.UseVisualStyleBackColor = true;
@@ -386,10 +364,9 @@ namespace WindowsVirtualDesktopHelper {
             // radioButtonPositionBottomLeft
             // 
             this.radioButtonPositionBottomLeft.AutoSize = true;
-            this.radioButtonPositionBottomLeft.Location = new System.Drawing.Point(6, 76);
-            this.radioButtonPositionBottomLeft.Margin = new System.Windows.Forms.Padding(6);
+            this.radioButtonPositionBottomLeft.Location = new System.Drawing.Point(3, 41);
             this.radioButtonPositionBottomLeft.Name = "radioButtonPositionBottomLeft";
-            this.radioButtonPositionBottomLeft.Size = new System.Drawing.Size(21, 20);
+            this.radioButtonPositionBottomLeft.Size = new System.Drawing.Size(14, 13);
             this.radioButtonPositionBottomLeft.TabIndex = 24;
             this.radioButtonPositionBottomLeft.TabStop = true;
             this.radioButtonPositionBottomLeft.UseVisualStyleBackColor = true;
@@ -397,10 +374,9 @@ namespace WindowsVirtualDesktopHelper {
             // radioButtonPositionMiddleRight
             // 
             this.radioButtonPositionMiddleRight.AutoSize = true;
-            this.radioButtonPositionMiddleRight.Location = new System.Drawing.Point(79, 41);
-            this.radioButtonPositionMiddleRight.Margin = new System.Windows.Forms.Padding(6);
+            this.radioButtonPositionMiddleRight.Location = new System.Drawing.Point(43, 22);
             this.radioButtonPositionMiddleRight.Name = "radioButtonPositionMiddleRight";
-            this.radioButtonPositionMiddleRight.Size = new System.Drawing.Size(21, 20);
+            this.radioButtonPositionMiddleRight.Size = new System.Drawing.Size(14, 13);
             this.radioButtonPositionMiddleRight.TabIndex = 23;
             this.radioButtonPositionMiddleRight.TabStop = true;
             this.radioButtonPositionMiddleRight.UseVisualStyleBackColor = true;
@@ -408,10 +384,9 @@ namespace WindowsVirtualDesktopHelper {
             // radioButtonPositionMiddleCenter
             // 
             this.radioButtonPositionMiddleCenter.AutoSize = true;
-            this.radioButtonPositionMiddleCenter.Location = new System.Drawing.Point(42, 41);
-            this.radioButtonPositionMiddleCenter.Margin = new System.Windows.Forms.Padding(6);
+            this.radioButtonPositionMiddleCenter.Location = new System.Drawing.Point(23, 22);
             this.radioButtonPositionMiddleCenter.Name = "radioButtonPositionMiddleCenter";
-            this.radioButtonPositionMiddleCenter.Size = new System.Drawing.Size(21, 20);
+            this.radioButtonPositionMiddleCenter.Size = new System.Drawing.Size(14, 13);
             this.radioButtonPositionMiddleCenter.TabIndex = 22;
             this.radioButtonPositionMiddleCenter.TabStop = true;
             this.radioButtonPositionMiddleCenter.UseVisualStyleBackColor = true;
@@ -419,10 +394,9 @@ namespace WindowsVirtualDesktopHelper {
             // radioButtonPositionMiddleLeft
             // 
             this.radioButtonPositionMiddleLeft.AutoSize = true;
-            this.radioButtonPositionMiddleLeft.Location = new System.Drawing.Point(6, 41);
-            this.radioButtonPositionMiddleLeft.Margin = new System.Windows.Forms.Padding(6);
+            this.radioButtonPositionMiddleLeft.Location = new System.Drawing.Point(3, 22);
             this.radioButtonPositionMiddleLeft.Name = "radioButtonPositionMiddleLeft";
-            this.radioButtonPositionMiddleLeft.Size = new System.Drawing.Size(21, 20);
+            this.radioButtonPositionMiddleLeft.Size = new System.Drawing.Size(14, 13);
             this.radioButtonPositionMiddleLeft.TabIndex = 21;
             this.radioButtonPositionMiddleLeft.TabStop = true;
             this.radioButtonPositionMiddleLeft.UseVisualStyleBackColor = true;
@@ -430,10 +404,9 @@ namespace WindowsVirtualDesktopHelper {
             // radioButtonPositionTopRight
             // 
             this.radioButtonPositionTopRight.AutoSize = true;
-            this.radioButtonPositionTopRight.Location = new System.Drawing.Point(79, 6);
-            this.radioButtonPositionTopRight.Margin = new System.Windows.Forms.Padding(6);
+            this.radioButtonPositionTopRight.Location = new System.Drawing.Point(43, 3);
             this.radioButtonPositionTopRight.Name = "radioButtonPositionTopRight";
-            this.radioButtonPositionTopRight.Size = new System.Drawing.Size(21, 20);
+            this.radioButtonPositionTopRight.Size = new System.Drawing.Size(14, 13);
             this.radioButtonPositionTopRight.TabIndex = 20;
             this.radioButtonPositionTopRight.TabStop = true;
             this.radioButtonPositionTopRight.UseVisualStyleBackColor = true;
@@ -441,10 +414,9 @@ namespace WindowsVirtualDesktopHelper {
             // radioButtonPositionTopCenter
             // 
             this.radioButtonPositionTopCenter.AutoSize = true;
-            this.radioButtonPositionTopCenter.Location = new System.Drawing.Point(42, 6);
-            this.radioButtonPositionTopCenter.Margin = new System.Windows.Forms.Padding(6);
+            this.radioButtonPositionTopCenter.Location = new System.Drawing.Point(23, 3);
             this.radioButtonPositionTopCenter.Name = "radioButtonPositionTopCenter";
-            this.radioButtonPositionTopCenter.Size = new System.Drawing.Size(21, 20);
+            this.radioButtonPositionTopCenter.Size = new System.Drawing.Size(14, 13);
             this.radioButtonPositionTopCenter.TabIndex = 19;
             this.radioButtonPositionTopCenter.TabStop = true;
             this.radioButtonPositionTopCenter.UseVisualStyleBackColor = true;
@@ -452,10 +424,9 @@ namespace WindowsVirtualDesktopHelper {
             // radioButtonPositionTopLeft
             // 
             this.radioButtonPositionTopLeft.AutoSize = true;
-            this.radioButtonPositionTopLeft.Location = new System.Drawing.Point(6, 6);
-            this.radioButtonPositionTopLeft.Margin = new System.Windows.Forms.Padding(6);
+            this.radioButtonPositionTopLeft.Location = new System.Drawing.Point(3, 3);
             this.radioButtonPositionTopLeft.Name = "radioButtonPositionTopLeft";
-            this.radioButtonPositionTopLeft.Size = new System.Drawing.Size(21, 20);
+            this.radioButtonPositionTopLeft.Size = new System.Drawing.Size(14, 13);
             this.radioButtonPositionTopLeft.TabIndex = 18;
             this.radioButtonPositionTopLeft.TabStop = true;
             this.radioButtonPositionTopLeft.UseVisualStyleBackColor = true;
@@ -463,20 +434,18 @@ namespace WindowsVirtualDesktopHelper {
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(73, 283);
-            this.label1.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.label1.Location = new System.Drawing.Point(40, 153);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(87, 25);
+            this.label1.Size = new System.Drawing.Size(47, 13);
             this.label1.TabIndex = 9;
             this.label1.Text = "Position:";
             // 
             // checkBoxOverlayTranslucent
             // 
             this.checkBoxOverlayTranslucent.AutoSize = true;
-            this.checkBoxOverlayTranslucent.Location = new System.Drawing.Point(79, 205);
-            this.checkBoxOverlayTranslucent.Margin = new System.Windows.Forms.Padding(6);
+            this.checkBoxOverlayTranslucent.Location = new System.Drawing.Point(43, 111);
             this.checkBoxOverlayTranslucent.Name = "checkBoxOverlayTranslucent";
-            this.checkBoxOverlayTranslucent.Size = new System.Drawing.Size(141, 29);
+            this.checkBoxOverlayTranslucent.Size = new System.Drawing.Size(82, 17);
             this.checkBoxOverlayTranslucent.TabIndex = 7;
             this.checkBoxOverlayTranslucent.Text = "Translucent";
             this.checkBoxOverlayTranslucent.UseVisualStyleBackColor = true;
@@ -484,10 +453,9 @@ namespace WindowsVirtualDesktopHelper {
             // checkBoxOverlayAnimate
             // 
             this.checkBoxOverlayAnimate.AutoSize = true;
-            this.checkBoxOverlayAnimate.Location = new System.Drawing.Point(79, 162);
-            this.checkBoxOverlayAnimate.Margin = new System.Windows.Forms.Padding(6);
+            this.checkBoxOverlayAnimate.Location = new System.Drawing.Point(43, 88);
             this.checkBoxOverlayAnimate.Name = "checkBoxOverlayAnimate";
-            this.checkBoxOverlayAnimate.Size = new System.Drawing.Size(169, 29);
+            this.checkBoxOverlayAnimate.Size = new System.Drawing.Size(98, 17);
             this.checkBoxOverlayAnimate.TabIndex = 6;
             this.checkBoxOverlayAnimate.Text = "Animate In/Out";
             this.checkBoxOverlayAnimate.UseVisualStyleBackColor = true;
@@ -495,10 +463,9 @@ namespace WindowsVirtualDesktopHelper {
             // checkBoxShowOverlay
             // 
             this.checkBoxShowOverlay.AutoSize = true;
-            this.checkBoxShowOverlay.Location = new System.Drawing.Point(28, 78);
-            this.checkBoxShowOverlay.Margin = new System.Windows.Forms.Padding(6);
+            this.checkBoxShowOverlay.Location = new System.Drawing.Point(15, 42);
             this.checkBoxShowOverlay.Name = "checkBoxShowOverlay";
-            this.checkBoxShowOverlay.Size = new System.Drawing.Size(375, 29);
+            this.checkBoxShowOverlay.Size = new System.Drawing.Size(211, 17);
             this.checkBoxShowOverlay.TabIndex = 2;
             this.checkBoxShowOverlay.Text = "Show Overlay when switching Desktop";
             this.checkBoxShowOverlay.UseVisualStyleBackColor = true;
@@ -507,11 +474,9 @@ namespace WindowsVirtualDesktopHelper {
             // groupBox2
             // 
             this.groupBox2.Controls.Add(this.checkBoxStartupWithWindows);
-            this.groupBox2.Location = new System.Drawing.Point(22, 601);
-            this.groupBox2.Margin = new System.Windows.Forms.Padding(6);
+            this.groupBox2.Location = new System.Drawing.Point(12, 326);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Padding = new System.Windows.Forms.Padding(6);
-            this.groupBox2.Size = new System.Drawing.Size(757, 89);
+            this.groupBox2.Size = new System.Drawing.Size(413, 48);
             this.groupBox2.TabIndex = 3;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Settings";
@@ -519,10 +484,9 @@ namespace WindowsVirtualDesktopHelper {
             // checkBoxStartupWithWindows
             // 
             this.checkBoxStartupWithWindows.AutoSize = true;
-            this.checkBoxStartupWithWindows.Location = new System.Drawing.Point(28, 35);
-            this.checkBoxStartupWithWindows.Margin = new System.Windows.Forms.Padding(6);
+            this.checkBoxStartupWithWindows.Location = new System.Drawing.Point(15, 19);
             this.checkBoxStartupWithWindows.Name = "checkBoxStartupWithWindows";
-            this.checkBoxStartupWithWindows.Size = new System.Drawing.Size(226, 29);
+            this.checkBoxStartupWithWindows.Size = new System.Drawing.Size(129, 17);
             this.checkBoxStartupWithWindows.TabIndex = 1;
             this.checkBoxStartupWithWindows.Text = "Startup with Windows";
             this.checkBoxStartupWithWindows.UseVisualStyleBackColor = true;
@@ -533,18 +497,16 @@ namespace WindowsVirtualDesktopHelper {
             this.notifyIconName.ContextMenuStrip = this.contextMenuStrip1;
             this.notifyIconName.Icon = ((System.Drawing.Icon)(resources.GetObject("notifyIconName.Icon")));
             this.notifyIconName.Text = "Desktop Name";
-            this.notifyIconName.Visible = true;
             this.notifyIconName.MouseClick += new System.Windows.Forms.MouseEventHandler(this.notifyIconName_MouseClick);
             // 
             // SettingsForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(11F, 24F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(805, 713);
+            this.ClientSize = new System.Drawing.Size(439, 386);
             this.Controls.Add(this.groupBox2);
             this.Controls.Add(this.groupBox1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
-            this.Margin = new System.Windows.Forms.Padding(6);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "SettingsForm";

--- a/Source/Forms/SettingsForm.cs
+++ b/Source/Forms/SettingsForm.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Drawing;
 using System.Globalization;
 using System.Windows.Forms;
 using WindowsVirtualDesktopHelper.WindowsHotKeyAPI;
@@ -59,6 +60,7 @@ namespace WindowsVirtualDesktopHelper {
 			// Set current display icons
 			UpdateIconForVDDisplayNumber(theme, App.Instance.CurrentVDDisplayNumber, App.Instance.CurrentVDDisplayName);
 			UpdateIconForVDDisplayName(theme, App.Instance.CurrentVDDisplayName);
+			UpdateNextPrevIconVisibility();
 		}
 		public ModifierKeys HotKeysToJumpToDesktop() {
 			if (this.radioButtonUseHotKeysToJumpToDesktopAlt.Checked) return WindowsHotKeyAPI.ModifierKeys.Alt;
@@ -167,8 +169,7 @@ namespace WindowsVirtualDesktopHelper {
 
 		public void UpdateIconForVDDisplayNumber(string theme, uint number, string name) {
 			number++;
-			this.notifyIconNumber.Icon = Util.Icons.GenerateNotificationIcon(number.ToString(), theme, this.DeviceDpi, false);
-			//this.notifyIconNumber.Text = name;
+			this.notifyIconNumber.Icon = Util.Icons.GenerateNotificationIcon(number.ToString(), theme, this.DeviceDpi, false, FontStyle.Bold);
 		}
 
 		public void UpdateIconForVDDisplayName(string theme, string name) {
@@ -181,16 +182,31 @@ namespace WindowsVirtualDesktopHelper {
 			}
 		}
 
+		public void UpdateNextPrevIconVisibility() {
+			int count = App.Instance.CurrentVDDisplayCount - 1;
+			if (checkBoxShowPrevNextIcons.Checked) {
+				if (count == 0 || App.Instance.CurrentVDDisplayNumber == count)
+					notifyIconNext.Visible = false;
+				else notifyIconNext.Visible = true;
+
+				if (App.Instance.CurrentVDDisplayNumber == 0)
+					notifyIconPrev.Visible = false;
+				else notifyIconPrev.Visible = true;
+			}
+		}
+
 		private void SettingsForm_Load(object sender, EventArgs e) {
 			App.Instance.ShowSplash();
 			App.Instance.MonitorVDSwitch();
 			App.Instance.MonitorFGWindowName();
 			App.Instance.MonitorSystemThemeSwitch();
+			App.Instance.MonitorVDisplayCount();
 		}
 
 		private void SettingsForm_Shown(object sender, EventArgs e) {
 			UpdateIconForVDDisplayNumber(App.Instance.CurrentSystemThemeName, App.Instance.CurrentVDDisplayNumber, App.Instance.CurrentVDDisplayName);
 			UpdateIconForVDDisplayName(App.Instance.CurrentSystemThemeName, App.Instance.CurrentVDDisplayName);
+			UpdateNextPrevIconVisibility();
 			this.notifyIconNumber.Visible = true;
 			this.Hide();
 		}
@@ -214,8 +230,9 @@ namespace WindowsVirtualDesktopHelper {
 			if (IsLoading) return;
 
 			if (checkBoxShowPrevNextIcons.Checked) {
-				notifyIconPrev.Visible = true;
-				notifyIconNext.Visible = true;
+				UpdateNextPrevIconVisibility();
+				//notifyIconPrev.Visible = true;
+				//notifyIconNext.Visible = true;
 			} else {
 				notifyIconPrev.Visible = false;
 				notifyIconNext.Visible = false;

--- a/Source/Util/Icons.cs
+++ b/Source/Util/Icons.cs
@@ -8,47 +8,47 @@ namespace WindowsVirtualDesktopHelper.Util {
 
         private static ConcurrentDictionary<string, Bitmap> _cache = new ConcurrentDictionary<string,Bitmap>();
 
-        public static Icon GenerateNotificationIcon(string text, string theme, int dpi, bool drawAsSymbol) {
+		public static Icon GenerateNotificationIcon(string text, string theme, int dpi, bool drawAsSymbol, FontStyle textStyle = FontStyle.Regular) {
 
 
-            // Init
-            var size = 16;
-            if (dpi > 96) size = 64;
-            var renderSize = 128; // GDI has really weak text drawing on transparent, so to get best results we render large then downscale...
-            var textStyle = FontStyle.Bold;
-            var textToRender = text;
-            if (textToRender == null) textToRender = ""; // sanity
+			// Init
+			var size = 16;
+			if (dpi > 96) size = 64;
+			var renderSize = 128; // GDI has really weak text drawing on transparent, so to get best results we render large then downscale...
+			//var textStyle = FontStyle.Bold;
+			var textToRender = text;
+			if (textToRender == null) textToRender = ""; // sanity
 			var textToRenderInfo = new StringInfo(textToRender);
 			if (textToRenderInfo.LengthInTextElements > 2) textToRender = new StringInfo(textToRender).SubstringByTextElements(0, 2);
 			var textToRenderSizeRatio = 1.0f;
-            if (textToRenderInfo.LengthInTextElements == 1) textToRenderSizeRatio = 0.9f;
-            if (textToRenderInfo.LengthInTextElements == 2) textToRenderSizeRatio = 0.5f;
-            if (textToRenderInfo.LengthInTextElements == 2) {
-                textToRenderSizeRatio = 0.75f;
-                textStyle = FontStyle.Regular;
-            }
-            var automaticFontSizeFitTolerance = 0.2f;
-            var offsetY = 0.0f;
-            var fontFamily = "Segoe UI";
-			if(Util.Emoji.HasEmoji(textToRender)) fontFamily = "Segoe UI Symbol";
+			if (textToRenderInfo.LengthInTextElements == 1) textToRenderSizeRatio = 0.9f;
+			if (textToRenderInfo.LengthInTextElements == 2) textToRenderSizeRatio = 0.5f;
+			if (textToRenderInfo.LengthInTextElements == 2) {
+				textToRenderSizeRatio = 0.75f;
+				textStyle = FontStyle.Regular;
+			}
+			var automaticFontSizeFitTolerance = 0.2f;
+			var offsetY = 0.0f;
+			var fontFamily = "Segoe UI";
+			if (Util.Emoji.HasEmoji(textToRender)) fontFamily = "Segoe UI Symbol";
 			if (drawAsSymbol) {
-                fontFamily = "Segoe UI Symbol";
-                textToRenderSizeRatio = 1.8f;
-                if (dpi > 96) textToRenderSizeRatio = 1.0f;
-                automaticFontSizeFitTolerance = 2.0f;
-                offsetY = -0.4f;
-            }
-            var textSize = renderSize * textToRenderSizeRatio;
+				fontFamily = "Segoe UI Symbol";
+				textToRenderSizeRatio = 1.8f;
+				if (dpi > 96) textToRenderSizeRatio = 1.0f;
+				automaticFontSizeFitTolerance = 2.0f;
+				offsetY = -0.4f;
+			}
+			var textSize = renderSize * textToRenderSizeRatio;
 
-            // Cache hit?
-            var cacheKey = textToRender + "_" + textSize + "_" + theme;
-            if(_cache.ContainsKey(cacheKey)) {
-                var cachedBitmap = _cache[cacheKey];
-                return Icon.FromHandle(cachedBitmap.GetHicon());
-            }
+			// Cache hit?
+			var cacheKey = textToRender + "_" + textSize + "_" + theme + "_" + textStyle;
+			if (_cache.ContainsKey(cacheKey)) {
+				var cachedBitmap = _cache[cacheKey];
+				return Icon.FromHandle(cachedBitmap.GetHicon());
+			}
 
-            // Theme
-            var fgBrush = Brushes.White;
+			// Theme
+			var fgBrush = Brushes.White;
             var fgColor = Color.White;
             var bgBrush = Brushes.Black;
             var bgColor = Color.Black;
@@ -115,11 +115,11 @@ namespace WindowsVirtualDesktopHelper.Util {
                 g.Flush();
             }
 
-            // Register in cache
-            _cache[cacheKey] = bitmapScaledDown;
+			// Register in cache
+			_cache[cacheKey] = bitmapScaledDown;
 
-            // Debug display
-            if (false && textToRender == "11"){
+			// Debug display
+			if (false && textToRender == "11"){
                 var form = new System.Windows.Forms.Form();
                 form.Width = size;
                 form.Height = size+30;

--- a/Source/Util/OS.cs
+++ b/Source/Util/OS.cs
@@ -27,11 +27,18 @@ namespace WindowsVirtualDesktopHelper.Util {
 		[DllImport("user32.dll")]
 		private static extern bool SetForegroundWindow(IntPtr hWnd);
 
+		[DllImport("user32.dll")]
+		private static extern bool EnumChildWindows(IntPtr hWndParent, EnumChildProc lpEnumFunc, IntPtr lParam);
+
+		private delegate bool EnumChildProc(IntPtr hWnd, IntPtr lParam);
+
+		[DllImport("user32.dll")]
+		private static extern IntPtr FindWindowA(string lpClassName, string lpWindowName);
+
 		public static string GetForegroundWindowName() {
 			IntPtr handle = GetForegroundWindow();
-			StringBuilder windowName = new StringBuilder(256);
-			GetWindowText(handle, windowName, windowName.Capacity);
-			return windowName.ToString();
+			string windowName = GetHandleWndName(handle);
+			return windowName;
 		}
 		
 		public static bool SetFocusWindow() {
@@ -39,9 +46,45 @@ namespace WindowsVirtualDesktopHelper.Util {
 			return SetForegroundWindow(handle);
 		}
 
-		public static void SetFocusWindowToDesktop() {
-			IntPtr desktopHandle = (IntPtr)0x0000000000070776;
+		public static void SetFocusWindowToDesktop(IntPtr hWnd) {
+			if (GetHandleWndName(hWnd) == "Folder View") {
+				SetForegroundWindow(hWnd);
+				return;
+			}
+			
+			// fallback
+			IntPtr desktopHandle = FindWindowA("Progman", "Program Manager");
+			if (desktopHandle == IntPtr.Zero) {
+				desktopHandle = FindWindowA("WorkerW", null);
+			}
+			
 			SetForegroundWindow(desktopHandle);
+		}
+
+		public static string GetHandleWndName(IntPtr hWnd) {
+			StringBuilder windowName = new StringBuilder(256);
+			GetWindowText(hWnd, windowName, windowName.Capacity);
+			return windowName.ToString();
+		}
+
+		public static IntPtr GetFolderViewHandle() {
+			IntPtr handle = GetForegroundWindow();
+			EnumChildWindows(handle, (hWndChild, lParam) => {
+				if (IsWindowVisible(hWndChild)) {
+					int length = GetWindowTextLength(hWndChild);
+					if (length > 0) {
+						StringBuilder sb = new StringBuilder(length + 1);
+						GetWindowText(hWndChild, sb, sb.Capacity);
+						if (sb.ToString() == "Folder View") {
+							handle = hWndChild;
+							return false;
+						}
+					}
+				}
+				return true;
+			}, IntPtr.Zero);
+
+			return handle;
 		}
 
 		public static void OpenTaskView() {

--- a/Source/Util/OS.cs
+++ b/Source/Util/OS.cs
@@ -34,7 +34,7 @@ namespace WindowsVirtualDesktopHelper.Util {
 			GetWindowText(handle, windowName, windowName.Capacity);
 			return windowName.ToString();
 		}
-
+		
 		public static bool SetFocusWindow() {
 			return SetForegroundWindow(GetForegroundWindow());
 		}

--- a/Source/Util/OS.cs
+++ b/Source/Util/OS.cs
@@ -25,7 +25,6 @@ namespace WindowsVirtualDesktopHelper.Util {
 		private static extern IntPtr GetForegroundWindow();
 
 		[DllImport("user32.dll")]
-		[return: MarshalAs(UnmanagedType.Bool)] 
 		private static extern bool SetForegroundWindow(IntPtr hWnd);
 
 		public static string GetForegroundWindowName() {
@@ -36,7 +35,13 @@ namespace WindowsVirtualDesktopHelper.Util {
 		}
 		
 		public static bool SetFocusWindow() {
-			return SetForegroundWindow(GetForegroundWindow());
+			IntPtr handle = GetForegroundWindow();
+			return SetForegroundWindow(handle);
+		}
+
+		public static void SetFocusWindowToDesktop() {
+			IntPtr desktopHandle = (IntPtr)0x0000000000070776;
+			SetForegroundWindow(desktopHandle);
 		}
 
 		public static void OpenTaskView() {

--- a/Source/Util/OS.cs
+++ b/Source/Util/OS.cs
@@ -24,11 +24,19 @@ namespace WindowsVirtualDesktopHelper.Util {
 		[DllImport("user32.dll")]
 		private static extern IntPtr GetForegroundWindow();
 
+		[DllImport("user32.dll")]
+		[return: MarshalAs(UnmanagedType.Bool)] 
+		private static extern bool SetForegroundWindow(IntPtr hWnd);
+
 		public static string GetForegroundWindowName() {
 			IntPtr handle = GetForegroundWindow();
 			StringBuilder windowName = new StringBuilder(256);
 			GetWindowText(handle, windowName, windowName.Capacity);
 			return windowName.ToString();
+		}
+
+		public static bool SetFocusWindow() {
+			return SetForegroundWindow(GetForegroundWindow());
 		}
 
 		public static void OpenTaskView() {

--- a/Source/VirtualDesktopAPI/IVirtualDesktopManager.cs
+++ b/Source/VirtualDesktopAPI/IVirtualDesktopManager.cs
@@ -6,6 +6,8 @@ namespace WindowsVirtualDesktopHelper.VirtualDesktopAPI {
 	public interface IVirtualDesktopManager {
 		uint Current();
 
+		int DisplayCount();
+
 		void SwitchForward();
 
 		void SwitchBackward();

--- a/Source/VirtualDesktopAPI/Implementation/VirtualDesktopWin10.cs
+++ b/Source/VirtualDesktopAPI/Implementation/VirtualDesktopWin10.cs
@@ -62,6 +62,10 @@ namespace WindowsVirtualDesktopHelper.VirtualDesktopAPI.Implementation {
 			return desktopName;
 		}
 
+		public int DisplayCount() {
+			return DesktopManager.VirtualDesktopManagerInternal.GetCount();
+		}
+
 		#region COM Guids
 
 		internal static class Guids {

--- a/Source/VirtualDesktopAPI/Implementation/VirtualDesktopWin11_21H2.cs
+++ b/Source/VirtualDesktopAPI/Implementation/VirtualDesktopWin11_21H2.cs
@@ -72,6 +72,10 @@ namespace WindowsVirtualDesktopHelper.VirtualDesktopAPI.Implementation {
 			return desktopName;
 		}
 
+		public int DisplayCount() {
+			return DesktopManager.VirtualDesktopManagerInternal.GetCount(IntPtr.Zero);
+		}
+
 		#region COM Guids
 
 		internal static class Guids {

--- a/Source/VirtualDesktopAPI/Implementation/VirtualDesktopWin11_22H2.cs
+++ b/Source/VirtualDesktopAPI/Implementation/VirtualDesktopWin11_22H2.cs
@@ -72,6 +72,10 @@ namespace WindowsVirtualDesktopHelper.VirtualDesktopAPI.Implementation {
 			return desktopName;
 		}
 
+		public int DisplayCount() {
+			return DesktopManager.VirtualDesktopManagerInternal.GetCount(IntPtr.Zero);
+		}
+
 		#region COM Guids
 
 		internal static class Guids {

--- a/Source/VirtualDesktopAPI/Implementation/VirtualDesktopWin11_23H2.cs
+++ b/Source/VirtualDesktopAPI/Implementation/VirtualDesktopWin11_23H2.cs
@@ -73,6 +73,10 @@ namespace WindowsVirtualDesktopHelper.VirtualDesktopAPI.Implementation {
 			return desktopName;
 		}
 
+		public int DisplayCount() {
+			return DesktopManager.VirtualDesktopManagerInternal.GetCount();
+		}
+
 		#region COM Guids
 
 		internal static class Guids {

--- a/Source/VirtualDesktopAPI/Implementation/VirtualDesktopWin11_23H2_2921.cs
+++ b/Source/VirtualDesktopAPI/Implementation/VirtualDesktopWin11_23H2_2921.cs
@@ -54,7 +54,7 @@ namespace WindowsVirtualDesktopHelper.VirtualDesktopAPI.Implementation {
 
 			bool isDifferentVD = App.Instance.CurrentVDDisplayNumber != number;
 			if (isDifferentVD)
-				Util.OS.SetFocusWindowToDesktop();
+				Util.OS.SetFocusWindowToDesktop(App.Instance.LastForegroundhWnd);
 			DesktopManager.VirtualDesktopManagerInternal.SwitchDesktop(desktop);
 			Util.OS.SetFocusWindow();
 		}

--- a/Source/VirtualDesktopAPI/Implementation/VirtualDesktopWin11_23H2_2921.cs
+++ b/Source/VirtualDesktopAPI/Implementation/VirtualDesktopWin11_23H2_2921.cs
@@ -50,7 +50,10 @@ namespace WindowsVirtualDesktopHelper.VirtualDesktopAPI.Implementation {
 
 		public void SwitchToDesktop(int number) {
 			var desktop = DesktopManager.GetDesktopAtIndex(number);
+			if (desktop == null) return;
+
 			DesktopManager.VirtualDesktopManagerInternal.SwitchDesktop(desktop);
+			Util.OS.SetFocusWindow();
 		}
 
 		public enum VirtualDesktopSwitchType {
@@ -71,6 +74,10 @@ namespace WindowsVirtualDesktopHelper.VirtualDesktopAPI.Implementation {
 			}
 
 			return desktopName;
+		}
+
+		public int DisplayCount() {
+			return DesktopManager.VirtualDesktopManagerInternal.GetCount();
 		}
 
 		#region COM Guids

--- a/Source/VirtualDesktopAPI/Implementation/VirtualDesktopWin11_23H2_2921.cs
+++ b/Source/VirtualDesktopAPI/Implementation/VirtualDesktopWin11_23H2_2921.cs
@@ -52,6 +52,9 @@ namespace WindowsVirtualDesktopHelper.VirtualDesktopAPI.Implementation {
 			var desktop = DesktopManager.GetDesktopAtIndex(number);
 			if (desktop == null) return;
 
+			bool isDifferentVD = App.Instance.CurrentVDDisplayNumber != number;
+			if (isDifferentVD)
+				Util.OS.SetFocusWindowToDesktop();
 			DesktopManager.VirtualDesktopManagerInternal.SwitchDesktop(desktop);
 			Util.OS.SetFocusWindow();
 		}

--- a/Source/VirtualDesktopAPI/Implementation/VirtualDesktopWin11_Insider.cs
+++ b/Source/VirtualDesktopAPI/Implementation/VirtualDesktopWin11_Insider.cs
@@ -65,6 +65,10 @@ namespace WindowsVirtualDesktopHelper.VirtualDesktopAPI.Implementation {
 			return desktopName;
 		}
 
+		public int DisplayCount() {
+			return DesktopManager.VirtualDesktopManagerInternal.GetCount(IntPtr.Zero);
+		}
+
 		#region COM API
 		internal static class Guids {
 			public static readonly Guid CLSID_ImmersiveShell = new Guid("C2F03A33-21F5-47FA-B4BB-156362A2F239");

--- a/Source/VirtualDesktopAPI/Implementation/VirtualDesktopWin11_Insider22631.cs
+++ b/Source/VirtualDesktopAPI/Implementation/VirtualDesktopWin11_Insider22631.cs
@@ -96,6 +96,10 @@ namespace WindowsVirtualDesktopHelper.VirtualDesktopAPI.Implementation {
 			return desktopName;
 		}
 
+		public int DisplayCount() {
+			return DesktopManager.VirtualDesktopManagerInternal.GetCount();
+		}
+
 		#region COM API
 		internal static class Guids {
 			public static readonly Guid CLSID_ImmersiveShell = new Guid("C2F03A33-21F5-47FA-B4BB-156362A2F239");

--- a/Source/VirtualDesktopAPI/Implementation/VirtualDesktopWin11_Insider25314.cs
+++ b/Source/VirtualDesktopAPI/Implementation/VirtualDesktopWin11_Insider25314.cs
@@ -73,6 +73,10 @@ namespace WindowsVirtualDesktopHelper.VirtualDesktopAPI.Implementation {
 			return desktopName;
 		}
 
+		public int DisplayCount() {
+			return DesktopManager.VirtualDesktopManagerInternal.GetCount();
+		}
+
 		#region COM API
 		internal static class Guids {
 			public static readonly Guid CLSID_ImmersiveShell = new Guid("C2F03A33-21F5-47FA-B4BB-156362A2F239");


### PR DESCRIPTION
fix breaks when switching to non-existent VD with hotkey on win11 23H2_2921 (https://github.com/dankrusi/WindowsVirtualDesktopHelper/issues/137)
fix grab foreground focus after switch virtual desktops on win11 23H2_2921 (https://github.com/dankrusi/WindowsVirtualDesktopHelper/issues/141)
feat: dynamically show/hide next/prev icon base on VD count and current VD


Tested
Windows 11 23H2 build 22631.3737
