### PR TITLE
Changed Feature: Use checkboxes for assigning the hotkey modifiers in the Settings Dialog to enable Win key modifier & catch registration errors

### DIFF
--- a/Source/App/App.cs
+++ b/Source/App/App.cs
@@ -308,7 +308,6 @@ namespace WindowsVirtualDesktopHelper {
 			}
 		}
 
-
 		public void MonitorFocusedWindow() {
 			var thread = new Thread(new ThreadStart(_monitorFocusedWindow));
 			thread.Start();
@@ -544,11 +543,24 @@ namespace WindowsVirtualDesktopHelper {
 			this._keyboardHooks.KeyPressed += new EventHandler<KeyPressedEventArgs>(_hotKeyPressed);
 
 			// Register all the hotkeys in _keyboardHooksHotKeysAndActions
+			List<string> hotkeyRegistrationErrors = new List<string>();
 			foreach(var hotkeyAction in _keyboardHooksHotKeysAndActions) {
-				this._keyboardHooks.RegisterHotKey(hotkeyAction.Modifiers, hotkeyAction.Keys);
+				try {
+					this._keyboardHooks.RegisterHotKey(hotkeyAction.Modifiers, hotkeyAction.Keys);
+				} catch (InvalidOperationException) {
+					hotkeyRegistrationErrors.Add($"{hotkeyAction.HotKeyAndAction}");
+				}
 			}
 
-
+			if (hotkeyRegistrationErrors.Any()) {
+				List<string> message = new List<string>();
+				message.Add("Could not register hotkeys:");
+				message.Add(Environment.NewLine);
+				message.AddRange(hotkeyRegistrationErrors);
+				message.Add(Environment.NewLine);
+				message.Add("Maybe this hotkey is already registered in another application??");
+				MessageBox.Show(string.Join(Environment.NewLine, message), "Hotkey Registration Error", MessageBoxButtons.OK);
+			}
 		}
 
 		private void _hotKeyPressed(object sender, KeyPressedEventArgs e) {
@@ -648,7 +660,6 @@ namespace WindowsVirtualDesktopHelper {
 			this.AppForm.notifyIconName.Visible = Settings.GetBool("feature.showDesktopNameInIconTray");
 			this.AppForm.notifyIconNumber.Visible = Settings.GetBool("feature.showDesktopNumberInIconTray");
 		}
-
 
 		public void UIUpdateIconForVDDisplayNumber(string theme, uint number, string name) {
 			number++;

--- a/Source/Forms/SettingsForm.Designer.cs
+++ b/Source/Forms/SettingsForm.Designer.cs
@@ -24,479 +24,458 @@ namespace WindowsVirtualDesktopHelper {
         /// the contents of this method with the code editor.
         /// </summary>
         private void InitializeComponent() {
-            this.checkBoxShowPrevNextIcons = new System.Windows.Forms.CheckBox();
-            this.groupBox1 = new System.Windows.Forms.GroupBox();
-            this.panel3 = new System.Windows.Forms.Panel();
-            this.radioButtonUseHotKeysToJumpToDesktopAlt = new System.Windows.Forms.RadioButton();
-            this.radioButtonUseHotKeysToJumpToDesktopAltShift = new System.Windows.Forms.RadioButton();
-            this.radioButtonUseHotKeysToJumpToDesktopCtrlAlt = new System.Windows.Forms.RadioButton();
-            this.radioButtonUseHotKeysToJumpToDesktopCtrl = new System.Windows.Forms.RadioButton();
-            this.checkBoxUseHotKeysToJumpToDesktop = new System.Windows.Forms.CheckBox();
-            this.checkBoxOverlayShowOnAllMonitors = new System.Windows.Forms.CheckBox();
-            this.checkBoxShowDesktopNameInitial = new System.Windows.Forms.CheckBox();
-            this.checkBoxClickDesktopNumberTaskView = new System.Windows.Forms.CheckBox();
-            this.panel2 = new System.Windows.Forms.Panel();
-            this.radioButtonOverlayMicroDuration = new System.Windows.Forms.RadioButton();
-            this.radioButtonOverlayLongDuration = new System.Windows.Forms.RadioButton();
-            this.radioButtonOverlayMediumDuration = new System.Windows.Forms.RadioButton();
-            this.radioButtonOverlayShortDuration = new System.Windows.Forms.RadioButton();
-            this.panel1 = new System.Windows.Forms.Panel();
-            this.radioButtonPositionBottomRight = new System.Windows.Forms.RadioButton();
-            this.radioButtonPositionBottomCenter = new System.Windows.Forms.RadioButton();
-            this.radioButtonPositionBottomLeft = new System.Windows.Forms.RadioButton();
-            this.radioButtonPositionMiddleRight = new System.Windows.Forms.RadioButton();
-            this.radioButtonPositionMiddleCenter = new System.Windows.Forms.RadioButton();
-            this.radioButtonPositionMiddleLeft = new System.Windows.Forms.RadioButton();
-            this.radioButtonPositionTopRight = new System.Windows.Forms.RadioButton();
-            this.radioButtonPositionTopCenter = new System.Windows.Forms.RadioButton();
-            this.radioButtonPositionTopLeft = new System.Windows.Forms.RadioButton();
-            this.label1 = new System.Windows.Forms.Label();
-            this.checkBoxOverlayTranslucent = new System.Windows.Forms.CheckBox();
-            this.checkBoxOverlayAnimate = new System.Windows.Forms.CheckBox();
-            this.checkBoxShowOverlay = new System.Windows.Forms.CheckBox();
-            this.groupBox2 = new System.Windows.Forms.GroupBox();
-            this.checkBoxStartupWithWindows = new System.Windows.Forms.CheckBox();
-            this.groupBox1.SuspendLayout();
-            this.panel3.SuspendLayout();
-            this.panel2.SuspendLayout();
-            this.panel1.SuspendLayout();
-            this.groupBox2.SuspendLayout();
-            this.SuspendLayout();
-            // 
-            // checkBoxShowPrevNextIcons
-            // 
-            this.checkBoxShowPrevNextIcons.AutoSize = true;
-            this.checkBoxShowPrevNextIcons.Location = new System.Drawing.Point(28, 35);
-            this.checkBoxShowPrevNextIcons.Margin = new System.Windows.Forms.Padding(6);
-            this.checkBoxShowPrevNextIcons.Name = "checkBoxShowPrevNextIcons";
-            this.checkBoxShowPrevNextIcons.Size = new System.Drawing.Size(409, 29);
-            this.checkBoxShowPrevNextIcons.TabIndex = 1;
-            this.checkBoxShowPrevNextIcons.Text = "Show Previous / Next Desktop in Icon Tray";
-            this.checkBoxShowPrevNextIcons.UseVisualStyleBackColor = true;
-            this.checkBoxShowPrevNextIcons.CheckedChanged += new System.EventHandler(this.checkBoxShowPrevNextIcons_CheckedChanged);
-            // 
-            // groupBox1
-            // 
-            this.groupBox1.Controls.Add(this.panel3);
-            this.groupBox1.Controls.Add(this.checkBoxUseHotKeysToJumpToDesktop);
-            this.groupBox1.Controls.Add(this.checkBoxOverlayShowOnAllMonitors);
-            this.groupBox1.Controls.Add(this.checkBoxShowDesktopNameInitial);
-            this.groupBox1.Controls.Add(this.checkBoxClickDesktopNumberTaskView);
-            this.groupBox1.Controls.Add(this.panel2);
-            this.groupBox1.Controls.Add(this.panel1);
-            this.groupBox1.Controls.Add(this.label1);
-            this.groupBox1.Controls.Add(this.checkBoxOverlayTranslucent);
-            this.groupBox1.Controls.Add(this.checkBoxOverlayAnimate);
-            this.groupBox1.Controls.Add(this.checkBoxShowOverlay);
-            this.groupBox1.Controls.Add(this.checkBoxShowPrevNextIcons);
-            this.groupBox1.Location = new System.Drawing.Point(22, 22);
-            this.groupBox1.Margin = new System.Windows.Forms.Padding(6);
-            this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Padding = new System.Windows.Forms.Padding(6);
-            this.groupBox1.Size = new System.Drawing.Size(757, 567);
-            this.groupBox1.TabIndex = 2;
-            this.groupBox1.TabStop = false;
-            this.groupBox1.Text = "Features";
-            // 
-            // panel3
-            // 
-            this.panel3.Controls.Add(this.radioButtonUseHotKeysToJumpToDesktopAlt);
-            this.panel3.Controls.Add(this.radioButtonUseHotKeysToJumpToDesktopAltShift);
-            this.panel3.Controls.Add(this.radioButtonUseHotKeysToJumpToDesktopCtrlAlt);
-            this.panel3.Controls.Add(this.radioButtonUseHotKeysToJumpToDesktopCtrl);
-            this.panel3.Location = new System.Drawing.Point(73, 510);
-            this.panel3.Margin = new System.Windows.Forms.Padding(6);
-            this.panel3.Name = "panel3";
-            this.panel3.Size = new System.Drawing.Size(660, 46);
-            this.panel3.TabIndex = 20;
-            // 
-            // radioButtonUseHotKeysToJumpToDesktopAlt
-            // 
-            this.radioButtonUseHotKeysToJumpToDesktopAlt.AutoSize = true;
-            this.radioButtonUseHotKeysToJumpToDesktopAlt.Location = new System.Drawing.Point(9, 9);
-            this.radioButtonUseHotKeysToJumpToDesktopAlt.Margin = new System.Windows.Forms.Padding(6);
-            this.radioButtonUseHotKeysToJumpToDesktopAlt.Name = "radioButtonUseHotKeysToJumpToDesktopAlt";
-            this.radioButtonUseHotKeysToJumpToDesktopAlt.Size = new System.Drawing.Size(83, 29);
-            this.radioButtonUseHotKeysToJumpToDesktopAlt.TabIndex = 9;
-            this.radioButtonUseHotKeysToJumpToDesktopAlt.TabStop = true;
-            this.radioButtonUseHotKeysToJumpToDesktopAlt.Text = "Alt+#";
-            this.radioButtonUseHotKeysToJumpToDesktopAlt.UseVisualStyleBackColor = true;
-            this.radioButtonUseHotKeysToJumpToDesktopAlt.CheckedChanged += new System.EventHandler(this.radioButtonUseHotKeysToJumpToDesktopAlt_CheckedChanged);
-            // 
-            // radioButtonUseHotKeysToJumpToDesktopAltShift
-            // 
-            this.radioButtonUseHotKeysToJumpToDesktopAltShift.AutoSize = true;
-            this.radioButtonUseHotKeysToJumpToDesktopAltShift.Location = new System.Drawing.Point(343, 9);
-            this.radioButtonUseHotKeysToJumpToDesktopAltShift.Margin = new System.Windows.Forms.Padding(6);
-            this.radioButtonUseHotKeysToJumpToDesktopAltShift.Name = "radioButtonUseHotKeysToJumpToDesktopAltShift";
-            this.radioButtonUseHotKeysToJumpToDesktopAltShift.Size = new System.Drawing.Size(134, 29);
-            this.radioButtonUseHotKeysToJumpToDesktopAltShift.TabIndex = 8;
-            this.radioButtonUseHotKeysToJumpToDesktopAltShift.TabStop = true;
-            this.radioButtonUseHotKeysToJumpToDesktopAltShift.Text = "Alt+Shift+#";
-            this.radioButtonUseHotKeysToJumpToDesktopAltShift.UseVisualStyleBackColor = true;
-            this.radioButtonUseHotKeysToJumpToDesktopAltShift.CheckedChanged += new System.EventHandler(this.radioButtonUseHotKeysToJumpToDesktopAltShift_CheckedChanged);
-            // 
-            // radioButtonUseHotKeysToJumpToDesktopCtrlAlt
-            // 
-            this.radioButtonUseHotKeysToJumpToDesktopCtrlAlt.AutoSize = true;
-            this.radioButtonUseHotKeysToJumpToDesktopCtrlAlt.Location = new System.Drawing.Point(205, 9);
-            this.radioButtonUseHotKeysToJumpToDesktopCtrlAlt.Margin = new System.Windows.Forms.Padding(6);
-            this.radioButtonUseHotKeysToJumpToDesktopCtrlAlt.Name = "radioButtonUseHotKeysToJumpToDesktopCtrlAlt";
-            this.radioButtonUseHotKeysToJumpToDesktopCtrlAlt.Size = new System.Drawing.Size(125, 29);
-            this.radioButtonUseHotKeysToJumpToDesktopCtrlAlt.TabIndex = 7;
-            this.radioButtonUseHotKeysToJumpToDesktopCtrlAlt.TabStop = true;
-            this.radioButtonUseHotKeysToJumpToDesktopCtrlAlt.Text = "Ctrl+Alt+#";
-            this.radioButtonUseHotKeysToJumpToDesktopCtrlAlt.UseVisualStyleBackColor = true;
-            this.radioButtonUseHotKeysToJumpToDesktopCtrlAlt.CheckedChanged += new System.EventHandler(this.radioButtonUseHotKeysToJumpToDesktopCtrlAlt_CheckedChanged);
-            // 
-            // radioButtonUseHotKeysToJumpToDesktopCtrl
-            // 
-            this.radioButtonUseHotKeysToJumpToDesktopCtrl.AutoSize = true;
-            this.radioButtonUseHotKeysToJumpToDesktopCtrl.Location = new System.Drawing.Point(104, 9);
-            this.radioButtonUseHotKeysToJumpToDesktopCtrl.Margin = new System.Windows.Forms.Padding(6);
-            this.radioButtonUseHotKeysToJumpToDesktopCtrl.Name = "radioButtonUseHotKeysToJumpToDesktopCtrl";
-            this.radioButtonUseHotKeysToJumpToDesktopCtrl.Size = new System.Drawing.Size(90, 29);
-            this.radioButtonUseHotKeysToJumpToDesktopCtrl.TabIndex = 6;
-            this.radioButtonUseHotKeysToJumpToDesktopCtrl.TabStop = true;
-            this.radioButtonUseHotKeysToJumpToDesktopCtrl.Text = "Ctrl+#";
-            this.radioButtonUseHotKeysToJumpToDesktopCtrl.UseVisualStyleBackColor = true;
-            this.radioButtonUseHotKeysToJumpToDesktopCtrl.CheckedChanged += new System.EventHandler(this.radioButtonUseHotKeysToJumpToDesktopCtrl_CheckedChanged);
-            // 
-            // checkBoxUseHotKeysToJumpToDesktop
-            // 
-            this.checkBoxUseHotKeysToJumpToDesktop.AutoSize = true;
-            this.checkBoxUseHotKeysToJumpToDesktop.Location = new System.Drawing.Point(28, 482);
-            this.checkBoxUseHotKeysToJumpToDesktop.Margin = new System.Windows.Forms.Padding(6);
-            this.checkBoxUseHotKeysToJumpToDesktop.Name = "checkBoxUseHotKeysToJumpToDesktop";
-            this.checkBoxUseHotKeysToJumpToDesktop.Size = new System.Drawing.Size(331, 29);
-            this.checkBoxUseHotKeysToJumpToDesktop.TabIndex = 23;
-            this.checkBoxUseHotKeysToJumpToDesktop.Text = "Use Hot Keys to Jump to Desktop";
-            this.checkBoxUseHotKeysToJumpToDesktop.UseVisualStyleBackColor = true;
-            this.checkBoxUseHotKeysToJumpToDesktop.CheckedChanged += new System.EventHandler(this.checkBoxUseHotKeysToJumpToDesktop_CheckedChanged);
-            // 
-            // checkBoxOverlayShowOnAllMonitors
-            // 
-            this.checkBoxOverlayShowOnAllMonitors.AutoSize = true;
-            this.checkBoxOverlayShowOnAllMonitors.Location = new System.Drawing.Point(79, 246);
-            this.checkBoxOverlayShowOnAllMonitors.Margin = new System.Windows.Forms.Padding(6);
-            this.checkBoxOverlayShowOnAllMonitors.Name = "checkBoxOverlayShowOnAllMonitors";
-            this.checkBoxOverlayShowOnAllMonitors.Size = new System.Drawing.Size(219, 29);
-            this.checkBoxOverlayShowOnAllMonitors.TabIndex = 22;
-            this.checkBoxOverlayShowOnAllMonitors.Text = "Show on all Monitors";
-            this.checkBoxOverlayShowOnAllMonitors.UseVisualStyleBackColor = true;
-            this.checkBoxOverlayShowOnAllMonitors.CheckedChanged += new System.EventHandler(this.checkBoxOverlayShowOnAllMonitors_CheckedChanged);
-            // 
-            // checkBoxShowDesktopNameInitial
-            // 
-            this.checkBoxShowDesktopNameInitial.AutoSize = true;
-            this.checkBoxShowDesktopNameInitial.Location = new System.Drawing.Point(28, 441);
-            this.checkBoxShowDesktopNameInitial.Margin = new System.Windows.Forms.Padding(6);
-            this.checkBoxShowDesktopNameInitial.Name = "checkBoxShowDesktopNameInitial";
-            this.checkBoxShowDesktopNameInitial.Size = new System.Drawing.Size(378, 29);
-            this.checkBoxShowDesktopNameInitial.TabIndex = 21;
-            this.checkBoxShowDesktopNameInitial.Text = "Show Desktop Name Initial in Icon Tray";
-            this.checkBoxShowDesktopNameInitial.UseVisualStyleBackColor = true;
-            this.checkBoxShowDesktopNameInitial.CheckedChanged += new System.EventHandler(this.checkBoxShowDesktopNameInitial_CheckedChanged);
-            // 
-            // checkBoxClickDesktopNumberTaskView
-            // 
-            this.checkBoxClickDesktopNumberTaskView.AutoSize = true;
-            this.checkBoxClickDesktopNumberTaskView.Location = new System.Drawing.Point(28, 401);
-            this.checkBoxClickDesktopNumberTaskView.Margin = new System.Windows.Forms.Padding(6);
-            this.checkBoxClickDesktopNumberTaskView.Name = "checkBoxClickDesktopNumberTaskView";
-            this.checkBoxClickDesktopNumberTaskView.Size = new System.Drawing.Size(521, 29);
-            this.checkBoxClickDesktopNumberTaskView.TabIndex = 20;
-            this.checkBoxClickDesktopNumberTaskView.Text = "Clicking Desktop Number in Icon Tray opens Task View";
-            this.checkBoxClickDesktopNumberTaskView.UseVisualStyleBackColor = true;
-            this.checkBoxClickDesktopNumberTaskView.CheckedChanged += new System.EventHandler(this.checkBoxClickDesktopNumberTaskView_CheckedChanged);
-            // 
-            // panel2
-            // 
-            this.panel2.Controls.Add(this.radioButtonOverlayMicroDuration);
-            this.panel2.Controls.Add(this.radioButtonOverlayLongDuration);
-            this.panel2.Controls.Add(this.radioButtonOverlayMediumDuration);
-            this.panel2.Controls.Add(this.radioButtonOverlayShortDuration);
-            this.panel2.Location = new System.Drawing.Point(73, 114);
-            this.panel2.Margin = new System.Windows.Forms.Padding(6);
-            this.panel2.Name = "panel2";
-            this.panel2.Size = new System.Drawing.Size(660, 46);
-            this.panel2.TabIndex = 19;
-            // 
-            // radioButtonOverlayMicroDuration
-            // 
-            this.radioButtonOverlayMicroDuration.AutoSize = true;
-            this.radioButtonOverlayMicroDuration.Location = new System.Drawing.Point(9, 9);
-            this.radioButtonOverlayMicroDuration.Margin = new System.Windows.Forms.Padding(6);
-            this.radioButtonOverlayMicroDuration.Name = "radioButtonOverlayMicroDuration";
-            this.radioButtonOverlayMicroDuration.Size = new System.Drawing.Size(96, 29);
-            this.radioButtonOverlayMicroDuration.TabIndex = 9;
-            this.radioButtonOverlayMicroDuration.TabStop = true;
-            this.radioButtonOverlayMicroDuration.Text = "500ms";
-            this.radioButtonOverlayMicroDuration.UseVisualStyleBackColor = true;
-            this.radioButtonOverlayMicroDuration.CheckedChanged += new System.EventHandler(this.radioButtonOverlayMicroDuration_CheckedChanged);
-            // 
-            // radioButtonOverlayLongDuration
-            // 
-            this.radioButtonOverlayLongDuration.AutoSize = true;
-            this.radioButtonOverlayLongDuration.Location = new System.Drawing.Point(372, 9);
-            this.radioButtonOverlayLongDuration.Margin = new System.Windows.Forms.Padding(6);
-            this.radioButtonOverlayLongDuration.Name = "radioButtonOverlayLongDuration";
-            this.radioButtonOverlayLongDuration.Size = new System.Drawing.Size(107, 29);
-            this.radioButtonOverlayLongDuration.TabIndex = 8;
-            this.radioButtonOverlayLongDuration.TabStop = true;
-            this.radioButtonOverlayLongDuration.Text = "3000ms";
-            this.radioButtonOverlayLongDuration.UseVisualStyleBackColor = true;
-            this.radioButtonOverlayLongDuration.CheckedChanged += new System.EventHandler(this.radioButtonOverlayLongDuration_CheckedChanged);
-            // 
-            // radioButtonOverlayMediumDuration
-            // 
-            this.radioButtonOverlayMediumDuration.AutoSize = true;
-            this.radioButtonOverlayMediumDuration.Location = new System.Drawing.Point(251, 9);
-            this.radioButtonOverlayMediumDuration.Margin = new System.Windows.Forms.Padding(6);
-            this.radioButtonOverlayMediumDuration.Name = "radioButtonOverlayMediumDuration";
-            this.radioButtonOverlayMediumDuration.Size = new System.Drawing.Size(107, 29);
-            this.radioButtonOverlayMediumDuration.TabIndex = 7;
-            this.radioButtonOverlayMediumDuration.TabStop = true;
-            this.radioButtonOverlayMediumDuration.Text = "2000ms";
-            this.radioButtonOverlayMediumDuration.UseVisualStyleBackColor = true;
-            this.radioButtonOverlayMediumDuration.CheckedChanged += new System.EventHandler(this.radioButtonOverlayMediumDuration_CheckedChanged);
-            // 
-            // radioButtonOverlayShortDuration
-            // 
-            this.radioButtonOverlayShortDuration.AutoSize = true;
-            this.radioButtonOverlayShortDuration.Location = new System.Drawing.Point(126, 9);
-            this.radioButtonOverlayShortDuration.Margin = new System.Windows.Forms.Padding(6);
-            this.radioButtonOverlayShortDuration.Name = "radioButtonOverlayShortDuration";
-            this.radioButtonOverlayShortDuration.Size = new System.Drawing.Size(107, 29);
-            this.radioButtonOverlayShortDuration.TabIndex = 6;
-            this.radioButtonOverlayShortDuration.TabStop = true;
-            this.radioButtonOverlayShortDuration.Text = "1000ms";
-            this.radioButtonOverlayShortDuration.UseVisualStyleBackColor = true;
-            this.radioButtonOverlayShortDuration.CheckedChanged += new System.EventHandler(this.radioButtonOverlayShortDuration_CheckedChanged);
-            // 
-            // panel1
-            // 
-            this.panel1.Controls.Add(this.radioButtonPositionBottomRight);
-            this.panel1.Controls.Add(this.radioButtonPositionBottomCenter);
-            this.panel1.Controls.Add(this.radioButtonPositionBottomLeft);
-            this.panel1.Controls.Add(this.radioButtonPositionMiddleRight);
-            this.panel1.Controls.Add(this.radioButtonPositionMiddleCenter);
-            this.panel1.Controls.Add(this.radioButtonPositionMiddleLeft);
-            this.panel1.Controls.Add(this.radioButtonPositionTopRight);
-            this.panel1.Controls.Add(this.radioButtonPositionTopCenter);
-            this.panel1.Controls.Add(this.radioButtonPositionTopLeft);
-            this.panel1.Location = new System.Drawing.Point(160, 281);
-            this.panel1.Margin = new System.Windows.Forms.Padding(6);
-            this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(114, 109);
-            this.panel1.TabIndex = 18;
-            // 
-            // radioButtonPositionBottomRight
-            // 
-            this.radioButtonPositionBottomRight.AutoSize = true;
-            this.radioButtonPositionBottomRight.Location = new System.Drawing.Point(79, 76);
-            this.radioButtonPositionBottomRight.Margin = new System.Windows.Forms.Padding(6);
-            this.radioButtonPositionBottomRight.Name = "radioButtonPositionBottomRight";
-            this.radioButtonPositionBottomRight.Size = new System.Drawing.Size(21, 20);
-            this.radioButtonPositionBottomRight.TabIndex = 26;
-            this.radioButtonPositionBottomRight.TabStop = true;
-            this.radioButtonPositionBottomRight.UseVisualStyleBackColor = true;
-            this.radioButtonPositionBottomRight.CheckedChanged += new System.EventHandler(this.radioButtonPositionBottomRight_CheckedChanged);
-            // 
-            // radioButtonPositionBottomCenter
-            // 
-            this.radioButtonPositionBottomCenter.AutoSize = true;
-            this.radioButtonPositionBottomCenter.Location = new System.Drawing.Point(42, 76);
-            this.radioButtonPositionBottomCenter.Margin = new System.Windows.Forms.Padding(6);
-            this.radioButtonPositionBottomCenter.Name = "radioButtonPositionBottomCenter";
-            this.radioButtonPositionBottomCenter.Size = new System.Drawing.Size(21, 20);
-            this.radioButtonPositionBottomCenter.TabIndex = 25;
-            this.radioButtonPositionBottomCenter.TabStop = true;
-            this.radioButtonPositionBottomCenter.UseVisualStyleBackColor = true;
-            this.radioButtonPositionBottomCenter.CheckedChanged += new System.EventHandler(this.radioButtonPositionBottomCenter_CheckedChanged);
-            // 
-            // radioButtonPositionBottomLeft
-            // 
-            this.radioButtonPositionBottomLeft.AutoSize = true;
-            this.radioButtonPositionBottomLeft.Location = new System.Drawing.Point(6, 76);
-            this.radioButtonPositionBottomLeft.Margin = new System.Windows.Forms.Padding(6);
-            this.radioButtonPositionBottomLeft.Name = "radioButtonPositionBottomLeft";
-            this.radioButtonPositionBottomLeft.Size = new System.Drawing.Size(21, 20);
-            this.radioButtonPositionBottomLeft.TabIndex = 24;
-            this.radioButtonPositionBottomLeft.TabStop = true;
-            this.radioButtonPositionBottomLeft.UseVisualStyleBackColor = true;
-            this.radioButtonPositionBottomLeft.CheckedChanged += new System.EventHandler(this.radioButtonPositionBottomLeft_CheckedChanged);
-            // 
-            // radioButtonPositionMiddleRight
-            // 
-            this.radioButtonPositionMiddleRight.AutoSize = true;
-            this.radioButtonPositionMiddleRight.Location = new System.Drawing.Point(79, 41);
-            this.radioButtonPositionMiddleRight.Margin = new System.Windows.Forms.Padding(6);
-            this.radioButtonPositionMiddleRight.Name = "radioButtonPositionMiddleRight";
-            this.radioButtonPositionMiddleRight.Size = new System.Drawing.Size(21, 20);
-            this.radioButtonPositionMiddleRight.TabIndex = 23;
-            this.radioButtonPositionMiddleRight.TabStop = true;
-            this.radioButtonPositionMiddleRight.UseVisualStyleBackColor = true;
-            this.radioButtonPositionMiddleRight.CheckedChanged += new System.EventHandler(this.radioButtonPositionMiddleRight_CheckedChanged);
-            // 
-            // radioButtonPositionMiddleCenter
-            // 
-            this.radioButtonPositionMiddleCenter.AutoSize = true;
-            this.radioButtonPositionMiddleCenter.Location = new System.Drawing.Point(42, 41);
-            this.radioButtonPositionMiddleCenter.Margin = new System.Windows.Forms.Padding(6);
-            this.radioButtonPositionMiddleCenter.Name = "radioButtonPositionMiddleCenter";
-            this.radioButtonPositionMiddleCenter.Size = new System.Drawing.Size(21, 20);
-            this.radioButtonPositionMiddleCenter.TabIndex = 22;
-            this.radioButtonPositionMiddleCenter.TabStop = true;
-            this.radioButtonPositionMiddleCenter.UseVisualStyleBackColor = true;
-            this.radioButtonPositionMiddleCenter.CheckedChanged += new System.EventHandler(this.radioButtonPositionMiddleCenter_CheckedChanged);
-            // 
-            // radioButtonPositionMiddleLeft
-            // 
-            this.radioButtonPositionMiddleLeft.AutoSize = true;
-            this.radioButtonPositionMiddleLeft.Location = new System.Drawing.Point(6, 41);
-            this.radioButtonPositionMiddleLeft.Margin = new System.Windows.Forms.Padding(6);
-            this.radioButtonPositionMiddleLeft.Name = "radioButtonPositionMiddleLeft";
-            this.radioButtonPositionMiddleLeft.Size = new System.Drawing.Size(21, 20);
-            this.radioButtonPositionMiddleLeft.TabIndex = 21;
-            this.radioButtonPositionMiddleLeft.TabStop = true;
-            this.radioButtonPositionMiddleLeft.UseVisualStyleBackColor = true;
-            this.radioButtonPositionMiddleLeft.CheckedChanged += new System.EventHandler(this.radioButtonPositionMiddleLeft_CheckedChanged);
-            // 
-            // radioButtonPositionTopRight
-            // 
-            this.radioButtonPositionTopRight.AutoSize = true;
-            this.radioButtonPositionTopRight.Location = new System.Drawing.Point(79, 6);
-            this.radioButtonPositionTopRight.Margin = new System.Windows.Forms.Padding(6);
-            this.radioButtonPositionTopRight.Name = "radioButtonPositionTopRight";
-            this.radioButtonPositionTopRight.Size = new System.Drawing.Size(21, 20);
-            this.radioButtonPositionTopRight.TabIndex = 20;
-            this.radioButtonPositionTopRight.TabStop = true;
-            this.radioButtonPositionTopRight.UseVisualStyleBackColor = true;
-            this.radioButtonPositionTopRight.CheckedChanged += new System.EventHandler(this.radioButtonPositionTopRight_CheckedChanged);
-            // 
-            // radioButtonPositionTopCenter
-            // 
-            this.radioButtonPositionTopCenter.AutoSize = true;
-            this.radioButtonPositionTopCenter.Location = new System.Drawing.Point(42, 6);
-            this.radioButtonPositionTopCenter.Margin = new System.Windows.Forms.Padding(6);
-            this.radioButtonPositionTopCenter.Name = "radioButtonPositionTopCenter";
-            this.radioButtonPositionTopCenter.Size = new System.Drawing.Size(21, 20);
-            this.radioButtonPositionTopCenter.TabIndex = 19;
-            this.radioButtonPositionTopCenter.TabStop = true;
-            this.radioButtonPositionTopCenter.UseVisualStyleBackColor = true;
-            this.radioButtonPositionTopCenter.CheckedChanged += new System.EventHandler(this.radioButtonPositionTopCenter_CheckedChanged);
-            // 
-            // radioButtonPositionTopLeft
-            // 
-            this.radioButtonPositionTopLeft.AutoSize = true;
-            this.radioButtonPositionTopLeft.Location = new System.Drawing.Point(6, 6);
-            this.radioButtonPositionTopLeft.Margin = new System.Windows.Forms.Padding(6);
-            this.radioButtonPositionTopLeft.Name = "radioButtonPositionTopLeft";
-            this.radioButtonPositionTopLeft.Size = new System.Drawing.Size(21, 20);
-            this.radioButtonPositionTopLeft.TabIndex = 18;
-            this.radioButtonPositionTopLeft.TabStop = true;
-            this.radioButtonPositionTopLeft.UseVisualStyleBackColor = true;
-            this.radioButtonPositionTopLeft.CheckedChanged += new System.EventHandler(this.radioButtonPositionTopLeft_CheckedChanged);
-            // 
-            // label1
-            // 
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(73, 282);
-            this.label1.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(87, 25);
-            this.label1.TabIndex = 9;
-            this.label1.Text = "Position:";
-            // 
-            // checkBoxOverlayTranslucent
-            // 
-            this.checkBoxOverlayTranslucent.AutoSize = true;
-            this.checkBoxOverlayTranslucent.Location = new System.Drawing.Point(79, 205);
-            this.checkBoxOverlayTranslucent.Margin = new System.Windows.Forms.Padding(6);
-            this.checkBoxOverlayTranslucent.Name = "checkBoxOverlayTranslucent";
-            this.checkBoxOverlayTranslucent.Size = new System.Drawing.Size(141, 29);
-            this.checkBoxOverlayTranslucent.TabIndex = 7;
-            this.checkBoxOverlayTranslucent.Text = "Translucent";
-            this.checkBoxOverlayTranslucent.UseVisualStyleBackColor = true;
-            this.checkBoxOverlayTranslucent.CheckedChanged += new System.EventHandler(this.checkBoxOverlayTranslucent_CheckedChanged);
-            // 
-            // checkBoxOverlayAnimate
-            // 
-            this.checkBoxOverlayAnimate.AutoSize = true;
-            this.checkBoxOverlayAnimate.Location = new System.Drawing.Point(79, 162);
-            this.checkBoxOverlayAnimate.Margin = new System.Windows.Forms.Padding(6);
-            this.checkBoxOverlayAnimate.Name = "checkBoxOverlayAnimate";
-            this.checkBoxOverlayAnimate.Size = new System.Drawing.Size(169, 29);
-            this.checkBoxOverlayAnimate.TabIndex = 6;
-            this.checkBoxOverlayAnimate.Text = "Animate In/Out";
-            this.checkBoxOverlayAnimate.UseVisualStyleBackColor = true;
-            this.checkBoxOverlayAnimate.CheckedChanged += new System.EventHandler(this.checkBoxOverlayAnimate_CheckedChanged);
-            // 
-            // checkBoxShowOverlay
-            // 
-            this.checkBoxShowOverlay.AutoSize = true;
-            this.checkBoxShowOverlay.Location = new System.Drawing.Point(28, 78);
-            this.checkBoxShowOverlay.Margin = new System.Windows.Forms.Padding(6);
-            this.checkBoxShowOverlay.Name = "checkBoxShowOverlay";
-            this.checkBoxShowOverlay.Size = new System.Drawing.Size(375, 29);
-            this.checkBoxShowOverlay.TabIndex = 2;
-            this.checkBoxShowOverlay.Text = "Show Overlay when switching Desktop";
-            this.checkBoxShowOverlay.UseVisualStyleBackColor = true;
-            this.checkBoxShowOverlay.CheckedChanged += new System.EventHandler(this.checkBoxShowOverlay_CheckedChanged);
-            // 
-            // groupBox2
-            // 
-            this.groupBox2.Controls.Add(this.checkBoxStartupWithWindows);
-            this.groupBox2.Location = new System.Drawing.Point(22, 602);
-            this.groupBox2.Margin = new System.Windows.Forms.Padding(6);
-            this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Padding = new System.Windows.Forms.Padding(6);
-            this.groupBox2.Size = new System.Drawing.Size(757, 89);
-            this.groupBox2.TabIndex = 3;
-            this.groupBox2.TabStop = false;
-            this.groupBox2.Text = "Settings";
-            // 
-            // checkBoxStartupWithWindows
-            // 
-            this.checkBoxStartupWithWindows.AutoSize = true;
-            this.checkBoxStartupWithWindows.Location = new System.Drawing.Point(28, 35);
-            this.checkBoxStartupWithWindows.Margin = new System.Windows.Forms.Padding(6);
-            this.checkBoxStartupWithWindows.Name = "checkBoxStartupWithWindows";
-            this.checkBoxStartupWithWindows.Size = new System.Drawing.Size(226, 29);
-            this.checkBoxStartupWithWindows.TabIndex = 1;
-            this.checkBoxStartupWithWindows.Text = "Startup with Windows";
-            this.checkBoxStartupWithWindows.UseVisualStyleBackColor = true;
-            this.checkBoxStartupWithWindows.CheckedChanged += new System.EventHandler(this.checkBoxStartupWithWindows_CheckedChanged);
-            // 
-            // SettingsForm
-            // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(11F, 24F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(805, 713);
-            this.Controls.Add(this.groupBox2);
-            this.Controls.Add(this.groupBox1);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
-            this.Margin = new System.Windows.Forms.Padding(6);
-            this.MaximizeBox = false;
-            this.MinimizeBox = false;
-            this.Name = "SettingsForm";
-            this.Text = "Settings";
-            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.SettingsForm_FormClosing);
-            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.SettingsForm_FormClosed);
-            this.Load += new System.EventHandler(this.SettingsForm_Load);
-            this.Shown += new System.EventHandler(this.SettingsForm_Shown);
-            this.groupBox1.ResumeLayout(false);
-            this.groupBox1.PerformLayout();
-            this.panel3.ResumeLayout(false);
-            this.panel3.PerformLayout();
-            this.panel2.ResumeLayout(false);
-            this.panel2.PerformLayout();
-            this.panel1.ResumeLayout(false);
-            this.panel1.PerformLayout();
-            this.groupBox2.ResumeLayout(false);
-            this.groupBox2.PerformLayout();
-            this.ResumeLayout(false);
+			this.checkBoxShowPrevNextIcons = new System.Windows.Forms.CheckBox();
+			this.groupBox1 = new System.Windows.Forms.GroupBox();
+			this.panel3 = new System.Windows.Forms.Panel();
+			this.checkBoxUseHotKeysToJumpToDesktop = new System.Windows.Forms.CheckBox();
+			this.checkBoxOverlayShowOnAllMonitors = new System.Windows.Forms.CheckBox();
+			this.checkBoxShowDesktopNameInitial = new System.Windows.Forms.CheckBox();
+			this.checkBoxClickDesktopNumberTaskView = new System.Windows.Forms.CheckBox();
+			this.panel2 = new System.Windows.Forms.Panel();
+			this.radioButtonOverlayMicroDuration = new System.Windows.Forms.RadioButton();
+			this.radioButtonOverlayLongDuration = new System.Windows.Forms.RadioButton();
+			this.radioButtonOverlayMediumDuration = new System.Windows.Forms.RadioButton();
+			this.radioButtonOverlayShortDuration = new System.Windows.Forms.RadioButton();
+			this.panel1 = new System.Windows.Forms.Panel();
+			this.radioButtonPositionBottomRight = new System.Windows.Forms.RadioButton();
+			this.radioButtonPositionBottomCenter = new System.Windows.Forms.RadioButton();
+			this.radioButtonPositionBottomLeft = new System.Windows.Forms.RadioButton();
+			this.radioButtonPositionMiddleRight = new System.Windows.Forms.RadioButton();
+			this.radioButtonPositionMiddleCenter = new System.Windows.Forms.RadioButton();
+			this.radioButtonPositionMiddleLeft = new System.Windows.Forms.RadioButton();
+			this.radioButtonPositionTopRight = new System.Windows.Forms.RadioButton();
+			this.radioButtonPositionTopCenter = new System.Windows.Forms.RadioButton();
+			this.radioButtonPositionTopLeft = new System.Windows.Forms.RadioButton();
+			this.label1 = new System.Windows.Forms.Label();
+			this.checkBoxOverlayTranslucent = new System.Windows.Forms.CheckBox();
+			this.checkBoxOverlayAnimate = new System.Windows.Forms.CheckBox();
+			this.checkBoxShowOverlay = new System.Windows.Forms.CheckBox();
+			this.groupBox2 = new System.Windows.Forms.GroupBox();
+			this.checkBoxStartupWithWindows = new System.Windows.Forms.CheckBox();
+			this.checkBoxUseHotKeysToJumpToDesktopCtrl = new System.Windows.Forms.CheckBox();
+			this.checkBoxUseHotKeysToJumpToDesktopAlt = new System.Windows.Forms.CheckBox();
+			this.checkBoxUseHotKeysToJumpToDesktopShift = new System.Windows.Forms.CheckBox();
+			this.checkBoxUseHotKeysToJumpToDesktopWin = new System.Windows.Forms.CheckBox();
+			this.labelKeyModifiersAreRequired = new System.Windows.Forms.Label();
+			this.groupBox1.SuspendLayout();
+			this.panel3.SuspendLayout();
+			this.panel2.SuspendLayout();
+			this.panel1.SuspendLayout();
+			this.groupBox2.SuspendLayout();
+			this.SuspendLayout();
+			// 
+			// checkBoxShowPrevNextIcons
+			// 
+			this.checkBoxShowPrevNextIcons.AutoSize = true;
+			this.checkBoxShowPrevNextIcons.Location = new System.Drawing.Point(15, 19);
+			this.checkBoxShowPrevNextIcons.Name = "checkBoxShowPrevNextIcons";
+			this.checkBoxShowPrevNextIcons.Size = new System.Drawing.Size(232, 17);
+			this.checkBoxShowPrevNextIcons.TabIndex = 1;
+			this.checkBoxShowPrevNextIcons.Text = "Show Previous / Next Desktop in Icon Tray";
+			this.checkBoxShowPrevNextIcons.UseVisualStyleBackColor = true;
+			this.checkBoxShowPrevNextIcons.CheckedChanged += new System.EventHandler(this.checkBoxShowPrevNextIcons_CheckedChanged);
+			// 
+			// groupBox1
+			// 
+			this.groupBox1.Controls.Add(this.panel3);
+			this.groupBox1.Controls.Add(this.checkBoxUseHotKeysToJumpToDesktop);
+			this.groupBox1.Controls.Add(this.checkBoxOverlayShowOnAllMonitors);
+			this.groupBox1.Controls.Add(this.checkBoxShowDesktopNameInitial);
+			this.groupBox1.Controls.Add(this.checkBoxClickDesktopNumberTaskView);
+			this.groupBox1.Controls.Add(this.panel2);
+			this.groupBox1.Controls.Add(this.panel1);
+			this.groupBox1.Controls.Add(this.label1);
+			this.groupBox1.Controls.Add(this.checkBoxOverlayTranslucent);
+			this.groupBox1.Controls.Add(this.checkBoxOverlayAnimate);
+			this.groupBox1.Controls.Add(this.checkBoxShowOverlay);
+			this.groupBox1.Controls.Add(this.checkBoxShowPrevNextIcons);
+			this.groupBox1.Location = new System.Drawing.Point(12, 12);
+			this.groupBox1.Name = "groupBox1";
+			this.groupBox1.Size = new System.Drawing.Size(413, 308);
+			this.groupBox1.TabIndex = 2;
+			this.groupBox1.TabStop = false;
+			this.groupBox1.Text = "Features";
+			// 
+			// panel3
+			// 
+			this.panel3.Controls.Add(this.labelKeyModifiersAreRequired);
+			this.panel3.Controls.Add(this.checkBoxUseHotKeysToJumpToDesktopWin);
+			this.panel3.Controls.Add(this.checkBoxUseHotKeysToJumpToDesktopShift);
+			this.panel3.Controls.Add(this.checkBoxUseHotKeysToJumpToDesktopAlt);
+			this.panel3.Controls.Add(this.checkBoxUseHotKeysToJumpToDesktopCtrl);
+			this.panel3.Location = new System.Drawing.Point(40, 276);
+			this.panel3.Name = "panel3";
+			this.panel3.Size = new System.Drawing.Size(360, 25);
+			this.panel3.TabIndex = 20;
+			// 
+			// checkBoxUseHotKeysToJumpToDesktop
+			// 
+			this.checkBoxUseHotKeysToJumpToDesktop.AutoSize = true;
+			this.checkBoxUseHotKeysToJumpToDesktop.Location = new System.Drawing.Point(15, 261);
+			this.checkBoxUseHotKeysToJumpToDesktop.Name = "checkBoxUseHotKeysToJumpToDesktop";
+			this.checkBoxUseHotKeysToJumpToDesktop.Size = new System.Drawing.Size(256, 17);
+			this.checkBoxUseHotKeysToJumpToDesktop.TabIndex = 23;
+			this.checkBoxUseHotKeysToJumpToDesktop.Text = "Use Hot Keys to Jump to Desktop (Modifiers + #)";
+			this.checkBoxUseHotKeysToJumpToDesktop.UseVisualStyleBackColor = true;
+			this.checkBoxUseHotKeysToJumpToDesktop.CheckedChanged += new System.EventHandler(this.checkBoxUseHotKeysToJumpToDesktop_CheckedChanged);
+			// 
+			// checkBoxOverlayShowOnAllMonitors
+			// 
+			this.checkBoxOverlayShowOnAllMonitors.AutoSize = true;
+			this.checkBoxOverlayShowOnAllMonitors.Location = new System.Drawing.Point(43, 133);
+			this.checkBoxOverlayShowOnAllMonitors.Name = "checkBoxOverlayShowOnAllMonitors";
+			this.checkBoxOverlayShowOnAllMonitors.Size = new System.Drawing.Size(124, 17);
+			this.checkBoxOverlayShowOnAllMonitors.TabIndex = 22;
+			this.checkBoxOverlayShowOnAllMonitors.Text = "Show on all Monitors";
+			this.checkBoxOverlayShowOnAllMonitors.UseVisualStyleBackColor = true;
+			this.checkBoxOverlayShowOnAllMonitors.CheckedChanged += new System.EventHandler(this.checkBoxOverlayShowOnAllMonitors_CheckedChanged);
+			// 
+			// checkBoxShowDesktopNameInitial
+			// 
+			this.checkBoxShowDesktopNameInitial.AutoSize = true;
+			this.checkBoxShowDesktopNameInitial.Location = new System.Drawing.Point(15, 239);
+			this.checkBoxShowDesktopNameInitial.Name = "checkBoxShowDesktopNameInitial";
+			this.checkBoxShowDesktopNameInitial.Size = new System.Drawing.Size(213, 17);
+			this.checkBoxShowDesktopNameInitial.TabIndex = 21;
+			this.checkBoxShowDesktopNameInitial.Text = "Show Desktop Name Initial in Icon Tray";
+			this.checkBoxShowDesktopNameInitial.UseVisualStyleBackColor = true;
+			this.checkBoxShowDesktopNameInitial.CheckedChanged += new System.EventHandler(this.checkBoxShowDesktopNameInitial_CheckedChanged);
+			// 
+			// checkBoxClickDesktopNumberTaskView
+			// 
+			this.checkBoxClickDesktopNumberTaskView.AutoSize = true;
+			this.checkBoxClickDesktopNumberTaskView.Location = new System.Drawing.Point(15, 217);
+			this.checkBoxClickDesktopNumberTaskView.Name = "checkBoxClickDesktopNumberTaskView";
+			this.checkBoxClickDesktopNumberTaskView.Size = new System.Drawing.Size(290, 17);
+			this.checkBoxClickDesktopNumberTaskView.TabIndex = 20;
+			this.checkBoxClickDesktopNumberTaskView.Text = "Clicking Desktop Number in Icon Tray opens Task View";
+			this.checkBoxClickDesktopNumberTaskView.UseVisualStyleBackColor = true;
+			this.checkBoxClickDesktopNumberTaskView.CheckedChanged += new System.EventHandler(this.checkBoxClickDesktopNumberTaskView_CheckedChanged);
+			// 
+			// panel2
+			// 
+			this.panel2.Controls.Add(this.radioButtonOverlayMicroDuration);
+			this.panel2.Controls.Add(this.radioButtonOverlayLongDuration);
+			this.panel2.Controls.Add(this.radioButtonOverlayMediumDuration);
+			this.panel2.Controls.Add(this.radioButtonOverlayShortDuration);
+			this.panel2.Location = new System.Drawing.Point(40, 62);
+			this.panel2.Name = "panel2";
+			this.panel2.Size = new System.Drawing.Size(360, 25);
+			this.panel2.TabIndex = 19;
+			// 
+			// radioButtonOverlayMicroDuration
+			// 
+			this.radioButtonOverlayMicroDuration.AutoSize = true;
+			this.radioButtonOverlayMicroDuration.Location = new System.Drawing.Point(5, 5);
+			this.radioButtonOverlayMicroDuration.Name = "radioButtonOverlayMicroDuration";
+			this.radioButtonOverlayMicroDuration.Size = new System.Drawing.Size(56, 17);
+			this.radioButtonOverlayMicroDuration.TabIndex = 9;
+			this.radioButtonOverlayMicroDuration.TabStop = true;
+			this.radioButtonOverlayMicroDuration.Text = "500ms";
+			this.radioButtonOverlayMicroDuration.UseVisualStyleBackColor = true;
+			this.radioButtonOverlayMicroDuration.CheckedChanged += new System.EventHandler(this.radioButtonOverlayMicroDuration_CheckedChanged);
+			// 
+			// radioButtonOverlayLongDuration
+			// 
+			this.radioButtonOverlayLongDuration.AutoSize = true;
+			this.radioButtonOverlayLongDuration.Location = new System.Drawing.Point(203, 5);
+			this.radioButtonOverlayLongDuration.Name = "radioButtonOverlayLongDuration";
+			this.radioButtonOverlayLongDuration.Size = new System.Drawing.Size(62, 17);
+			this.radioButtonOverlayLongDuration.TabIndex = 8;
+			this.radioButtonOverlayLongDuration.TabStop = true;
+			this.radioButtonOverlayLongDuration.Text = "3000ms";
+			this.radioButtonOverlayLongDuration.UseVisualStyleBackColor = true;
+			this.radioButtonOverlayLongDuration.CheckedChanged += new System.EventHandler(this.radioButtonOverlayLongDuration_CheckedChanged);
+			// 
+			// radioButtonOverlayMediumDuration
+			// 
+			this.radioButtonOverlayMediumDuration.AutoSize = true;
+			this.radioButtonOverlayMediumDuration.Location = new System.Drawing.Point(137, 5);
+			this.radioButtonOverlayMediumDuration.Name = "radioButtonOverlayMediumDuration";
+			this.radioButtonOverlayMediumDuration.Size = new System.Drawing.Size(62, 17);
+			this.radioButtonOverlayMediumDuration.TabIndex = 7;
+			this.radioButtonOverlayMediumDuration.TabStop = true;
+			this.radioButtonOverlayMediumDuration.Text = "2000ms";
+			this.radioButtonOverlayMediumDuration.UseVisualStyleBackColor = true;
+			this.radioButtonOverlayMediumDuration.CheckedChanged += new System.EventHandler(this.radioButtonOverlayMediumDuration_CheckedChanged);
+			// 
+			// radioButtonOverlayShortDuration
+			// 
+			this.radioButtonOverlayShortDuration.AutoSize = true;
+			this.radioButtonOverlayShortDuration.Location = new System.Drawing.Point(69, 5);
+			this.radioButtonOverlayShortDuration.Name = "radioButtonOverlayShortDuration";
+			this.radioButtonOverlayShortDuration.Size = new System.Drawing.Size(62, 17);
+			this.radioButtonOverlayShortDuration.TabIndex = 6;
+			this.radioButtonOverlayShortDuration.TabStop = true;
+			this.radioButtonOverlayShortDuration.Text = "1000ms";
+			this.radioButtonOverlayShortDuration.UseVisualStyleBackColor = true;
+			this.radioButtonOverlayShortDuration.CheckedChanged += new System.EventHandler(this.radioButtonOverlayShortDuration_CheckedChanged);
+			// 
+			// panel1
+			// 
+			this.panel1.Controls.Add(this.radioButtonPositionBottomRight);
+			this.panel1.Controls.Add(this.radioButtonPositionBottomCenter);
+			this.panel1.Controls.Add(this.radioButtonPositionBottomLeft);
+			this.panel1.Controls.Add(this.radioButtonPositionMiddleRight);
+			this.panel1.Controls.Add(this.radioButtonPositionMiddleCenter);
+			this.panel1.Controls.Add(this.radioButtonPositionMiddleLeft);
+			this.panel1.Controls.Add(this.radioButtonPositionTopRight);
+			this.panel1.Controls.Add(this.radioButtonPositionTopCenter);
+			this.panel1.Controls.Add(this.radioButtonPositionTopLeft);
+			this.panel1.Location = new System.Drawing.Point(87, 152);
+			this.panel1.Name = "panel1";
+			this.panel1.Size = new System.Drawing.Size(62, 59);
+			this.panel1.TabIndex = 18;
+			// 
+			// radioButtonPositionBottomRight
+			// 
+			this.radioButtonPositionBottomRight.AutoSize = true;
+			this.radioButtonPositionBottomRight.Location = new System.Drawing.Point(43, 41);
+			this.radioButtonPositionBottomRight.Name = "radioButtonPositionBottomRight";
+			this.radioButtonPositionBottomRight.Size = new System.Drawing.Size(14, 13);
+			this.radioButtonPositionBottomRight.TabIndex = 26;
+			this.radioButtonPositionBottomRight.TabStop = true;
+			this.radioButtonPositionBottomRight.UseVisualStyleBackColor = true;
+			this.radioButtonPositionBottomRight.CheckedChanged += new System.EventHandler(this.radioButtonPositionBottomRight_CheckedChanged);
+			// 
+			// radioButtonPositionBottomCenter
+			// 
+			this.radioButtonPositionBottomCenter.AutoSize = true;
+			this.radioButtonPositionBottomCenter.Location = new System.Drawing.Point(23, 41);
+			this.radioButtonPositionBottomCenter.Name = "radioButtonPositionBottomCenter";
+			this.radioButtonPositionBottomCenter.Size = new System.Drawing.Size(14, 13);
+			this.radioButtonPositionBottomCenter.TabIndex = 25;
+			this.radioButtonPositionBottomCenter.TabStop = true;
+			this.radioButtonPositionBottomCenter.UseVisualStyleBackColor = true;
+			this.radioButtonPositionBottomCenter.CheckedChanged += new System.EventHandler(this.radioButtonPositionBottomCenter_CheckedChanged);
+			// 
+			// radioButtonPositionBottomLeft
+			// 
+			this.radioButtonPositionBottomLeft.AutoSize = true;
+			this.radioButtonPositionBottomLeft.Location = new System.Drawing.Point(3, 41);
+			this.radioButtonPositionBottomLeft.Name = "radioButtonPositionBottomLeft";
+			this.radioButtonPositionBottomLeft.Size = new System.Drawing.Size(14, 13);
+			this.radioButtonPositionBottomLeft.TabIndex = 24;
+			this.radioButtonPositionBottomLeft.TabStop = true;
+			this.radioButtonPositionBottomLeft.UseVisualStyleBackColor = true;
+			this.radioButtonPositionBottomLeft.CheckedChanged += new System.EventHandler(this.radioButtonPositionBottomLeft_CheckedChanged);
+			// 
+			// radioButtonPositionMiddleRight
+			// 
+			this.radioButtonPositionMiddleRight.AutoSize = true;
+			this.radioButtonPositionMiddleRight.Location = new System.Drawing.Point(43, 22);
+			this.radioButtonPositionMiddleRight.Name = "radioButtonPositionMiddleRight";
+			this.radioButtonPositionMiddleRight.Size = new System.Drawing.Size(14, 13);
+			this.radioButtonPositionMiddleRight.TabIndex = 23;
+			this.radioButtonPositionMiddleRight.TabStop = true;
+			this.radioButtonPositionMiddleRight.UseVisualStyleBackColor = true;
+			this.radioButtonPositionMiddleRight.CheckedChanged += new System.EventHandler(this.radioButtonPositionMiddleRight_CheckedChanged);
+			// 
+			// radioButtonPositionMiddleCenter
+			// 
+			this.radioButtonPositionMiddleCenter.AutoSize = true;
+			this.radioButtonPositionMiddleCenter.Location = new System.Drawing.Point(23, 22);
+			this.radioButtonPositionMiddleCenter.Name = "radioButtonPositionMiddleCenter";
+			this.radioButtonPositionMiddleCenter.Size = new System.Drawing.Size(14, 13);
+			this.radioButtonPositionMiddleCenter.TabIndex = 22;
+			this.radioButtonPositionMiddleCenter.TabStop = true;
+			this.radioButtonPositionMiddleCenter.UseVisualStyleBackColor = true;
+			this.radioButtonPositionMiddleCenter.CheckedChanged += new System.EventHandler(this.radioButtonPositionMiddleCenter_CheckedChanged);
+			// 
+			// radioButtonPositionMiddleLeft
+			// 
+			this.radioButtonPositionMiddleLeft.AutoSize = true;
+			this.radioButtonPositionMiddleLeft.Location = new System.Drawing.Point(3, 22);
+			this.radioButtonPositionMiddleLeft.Name = "radioButtonPositionMiddleLeft";
+			this.radioButtonPositionMiddleLeft.Size = new System.Drawing.Size(14, 13);
+			this.radioButtonPositionMiddleLeft.TabIndex = 21;
+			this.radioButtonPositionMiddleLeft.TabStop = true;
+			this.radioButtonPositionMiddleLeft.UseVisualStyleBackColor = true;
+			this.radioButtonPositionMiddleLeft.CheckedChanged += new System.EventHandler(this.radioButtonPositionMiddleLeft_CheckedChanged);
+			// 
+			// radioButtonPositionTopRight
+			// 
+			this.radioButtonPositionTopRight.AutoSize = true;
+			this.radioButtonPositionTopRight.Location = new System.Drawing.Point(43, 3);
+			this.radioButtonPositionTopRight.Name = "radioButtonPositionTopRight";
+			this.radioButtonPositionTopRight.Size = new System.Drawing.Size(14, 13);
+			this.radioButtonPositionTopRight.TabIndex = 20;
+			this.radioButtonPositionTopRight.TabStop = true;
+			this.radioButtonPositionTopRight.UseVisualStyleBackColor = true;
+			this.radioButtonPositionTopRight.CheckedChanged += new System.EventHandler(this.radioButtonPositionTopRight_CheckedChanged);
+			// 
+			// radioButtonPositionTopCenter
+			// 
+			this.radioButtonPositionTopCenter.AutoSize = true;
+			this.radioButtonPositionTopCenter.Location = new System.Drawing.Point(23, 3);
+			this.radioButtonPositionTopCenter.Name = "radioButtonPositionTopCenter";
+			this.radioButtonPositionTopCenter.Size = new System.Drawing.Size(14, 13);
+			this.radioButtonPositionTopCenter.TabIndex = 19;
+			this.radioButtonPositionTopCenter.TabStop = true;
+			this.radioButtonPositionTopCenter.UseVisualStyleBackColor = true;
+			this.radioButtonPositionTopCenter.CheckedChanged += new System.EventHandler(this.radioButtonPositionTopCenter_CheckedChanged);
+			// 
+			// radioButtonPositionTopLeft
+			// 
+			this.radioButtonPositionTopLeft.AutoSize = true;
+			this.radioButtonPositionTopLeft.Location = new System.Drawing.Point(3, 3);
+			this.radioButtonPositionTopLeft.Name = "radioButtonPositionTopLeft";
+			this.radioButtonPositionTopLeft.Size = new System.Drawing.Size(14, 13);
+			this.radioButtonPositionTopLeft.TabIndex = 18;
+			this.radioButtonPositionTopLeft.TabStop = true;
+			this.radioButtonPositionTopLeft.UseVisualStyleBackColor = true;
+			this.radioButtonPositionTopLeft.CheckedChanged += new System.EventHandler(this.radioButtonPositionTopLeft_CheckedChanged);
+			// 
+			// label1
+			// 
+			this.label1.AutoSize = true;
+			this.label1.Location = new System.Drawing.Point(40, 153);
+			this.label1.Name = "label1";
+			this.label1.Size = new System.Drawing.Size(47, 13);
+			this.label1.TabIndex = 9;
+			this.label1.Text = "Position:";
+			// 
+			// checkBoxOverlayTranslucent
+			// 
+			this.checkBoxOverlayTranslucent.AutoSize = true;
+			this.checkBoxOverlayTranslucent.Location = new System.Drawing.Point(43, 111);
+			this.checkBoxOverlayTranslucent.Name = "checkBoxOverlayTranslucent";
+			this.checkBoxOverlayTranslucent.Size = new System.Drawing.Size(82, 17);
+			this.checkBoxOverlayTranslucent.TabIndex = 7;
+			this.checkBoxOverlayTranslucent.Text = "Translucent";
+			this.checkBoxOverlayTranslucent.UseVisualStyleBackColor = true;
+			this.checkBoxOverlayTranslucent.CheckedChanged += new System.EventHandler(this.checkBoxOverlayTranslucent_CheckedChanged);
+			// 
+			// checkBoxOverlayAnimate
+			// 
+			this.checkBoxOverlayAnimate.AutoSize = true;
+			this.checkBoxOverlayAnimate.Location = new System.Drawing.Point(43, 88);
+			this.checkBoxOverlayAnimate.Name = "checkBoxOverlayAnimate";
+			this.checkBoxOverlayAnimate.Size = new System.Drawing.Size(98, 17);
+			this.checkBoxOverlayAnimate.TabIndex = 6;
+			this.checkBoxOverlayAnimate.Text = "Animate In/Out";
+			this.checkBoxOverlayAnimate.UseVisualStyleBackColor = true;
+			this.checkBoxOverlayAnimate.CheckedChanged += new System.EventHandler(this.checkBoxOverlayAnimate_CheckedChanged);
+			// 
+			// checkBoxShowOverlay
+			// 
+			this.checkBoxShowOverlay.AutoSize = true;
+			this.checkBoxShowOverlay.Location = new System.Drawing.Point(15, 42);
+			this.checkBoxShowOverlay.Name = "checkBoxShowOverlay";
+			this.checkBoxShowOverlay.Size = new System.Drawing.Size(211, 17);
+			this.checkBoxShowOverlay.TabIndex = 2;
+			this.checkBoxShowOverlay.Text = "Show Overlay when switching Desktop";
+			this.checkBoxShowOverlay.UseVisualStyleBackColor = true;
+			this.checkBoxShowOverlay.CheckedChanged += new System.EventHandler(this.checkBoxShowOverlay_CheckedChanged);
+			// 
+			// groupBox2
+			// 
+			this.groupBox2.Controls.Add(this.checkBoxStartupWithWindows);
+			this.groupBox2.Location = new System.Drawing.Point(12, 326);
+			this.groupBox2.Name = "groupBox2";
+			this.groupBox2.Size = new System.Drawing.Size(413, 48);
+			this.groupBox2.TabIndex = 3;
+			this.groupBox2.TabStop = false;
+			this.groupBox2.Text = "Settings";
+			// 
+			// checkBoxStartupWithWindows
+			// 
+			this.checkBoxStartupWithWindows.AutoSize = true;
+			this.checkBoxStartupWithWindows.Location = new System.Drawing.Point(15, 19);
+			this.checkBoxStartupWithWindows.Name = "checkBoxStartupWithWindows";
+			this.checkBoxStartupWithWindows.Size = new System.Drawing.Size(129, 17);
+			this.checkBoxStartupWithWindows.TabIndex = 1;
+			this.checkBoxStartupWithWindows.Text = "Startup with Windows";
+			this.checkBoxStartupWithWindows.UseVisualStyleBackColor = true;
+			this.checkBoxStartupWithWindows.CheckedChanged += new System.EventHandler(this.checkBoxStartupWithWindows_CheckedChanged);
+			// 
+			// checkBoxUseHotKeysToJumpToDesktopCtrl
+			// 
+			this.checkBoxUseHotKeysToJumpToDesktopCtrl.AutoSize = true;
+			this.checkBoxUseHotKeysToJumpToDesktopCtrl.Dock = System.Windows.Forms.DockStyle.Left;
+			this.checkBoxUseHotKeysToJumpToDesktopCtrl.Location = new System.Drawing.Point(0, 0);
+			this.checkBoxUseHotKeysToJumpToDesktopCtrl.Name = "checkBoxUseHotKeysToJumpToDesktopCtrl";
+			this.checkBoxUseHotKeysToJumpToDesktopCtrl.Size = new System.Drawing.Size(41, 25);
+			this.checkBoxUseHotKeysToJumpToDesktopCtrl.TabIndex = 24;
+			this.checkBoxUseHotKeysToJumpToDesktopCtrl.Text = "Ctrl";
+			this.checkBoxUseHotKeysToJumpToDesktopCtrl.UseVisualStyleBackColor = true;
+			this.checkBoxUseHotKeysToJumpToDesktopCtrl.CheckedChanged += new System.EventHandler(this.checkBoxUseHotKeysToJumpToDesktopModifier_CheckedChanged);
+			// 
+			// checkBoxUseHotKeysToJumpToDesktopAlt
+			// 
+			this.checkBoxUseHotKeysToJumpToDesktopAlt.AutoSize = true;
+			this.checkBoxUseHotKeysToJumpToDesktopAlt.Dock = System.Windows.Forms.DockStyle.Left;
+			this.checkBoxUseHotKeysToJumpToDesktopAlt.Location = new System.Drawing.Point(41, 0);
+			this.checkBoxUseHotKeysToJumpToDesktopAlt.Name = "checkBoxUseHotKeysToJumpToDesktopAlt";
+			this.checkBoxUseHotKeysToJumpToDesktopAlt.Size = new System.Drawing.Size(38, 25);
+			this.checkBoxUseHotKeysToJumpToDesktopAlt.TabIndex = 25;
+			this.checkBoxUseHotKeysToJumpToDesktopAlt.Text = "Alt";
+			this.checkBoxUseHotKeysToJumpToDesktopAlt.UseVisualStyleBackColor = true;
+			this.checkBoxUseHotKeysToJumpToDesktopAlt.CheckedChanged += new System.EventHandler(this.checkBoxUseHotKeysToJumpToDesktopModifier_CheckedChanged);
+			// 
+			// checkBoxUseHotKeysToJumpToDesktopShift
+			// 
+			this.checkBoxUseHotKeysToJumpToDesktopShift.AutoSize = true;
+			this.checkBoxUseHotKeysToJumpToDesktopShift.Dock = System.Windows.Forms.DockStyle.Left;
+			this.checkBoxUseHotKeysToJumpToDesktopShift.Location = new System.Drawing.Point(79, 0);
+			this.checkBoxUseHotKeysToJumpToDesktopShift.Name = "checkBoxUseHotKeysToJumpToDesktopShift";
+			this.checkBoxUseHotKeysToJumpToDesktopShift.Size = new System.Drawing.Size(47, 25);
+			this.checkBoxUseHotKeysToJumpToDesktopShift.TabIndex = 26;
+			this.checkBoxUseHotKeysToJumpToDesktopShift.Text = "Shift";
+			this.checkBoxUseHotKeysToJumpToDesktopShift.UseVisualStyleBackColor = true;
+			this.checkBoxUseHotKeysToJumpToDesktopShift.CheckedChanged += new System.EventHandler(this.checkBoxUseHotKeysToJumpToDesktopModifier_CheckedChanged);
+			// 
+			// checkBoxUseHotKeysToJumpToDesktopWin
+			// 
+			this.checkBoxUseHotKeysToJumpToDesktopWin.AutoSize = true;
+			this.checkBoxUseHotKeysToJumpToDesktopWin.Dock = System.Windows.Forms.DockStyle.Left;
+			this.checkBoxUseHotKeysToJumpToDesktopWin.Location = new System.Drawing.Point(126, 0);
+			this.checkBoxUseHotKeysToJumpToDesktopWin.Name = "checkBoxUseHotKeysToJumpToDesktopWin";
+			this.checkBoxUseHotKeysToJumpToDesktopWin.Size = new System.Drawing.Size(45, 25);
+			this.checkBoxUseHotKeysToJumpToDesktopWin.TabIndex = 27;
+			this.checkBoxUseHotKeysToJumpToDesktopWin.Text = "Win";
+			this.checkBoxUseHotKeysToJumpToDesktopWin.UseVisualStyleBackColor = true;
+			this.checkBoxUseHotKeysToJumpToDesktopWin.CheckedChanged += new System.EventHandler(this.checkBoxUseHotKeysToJumpToDesktopModifier_CheckedChanged);
+			// 
+			// labelKeyModifiersAreRequired
+			// 
+			this.labelKeyModifiersAreRequired.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.labelKeyModifiersAreRequired.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.labelKeyModifiersAreRequired.ForeColor = System.Drawing.Color.Red;
+			this.labelKeyModifiersAreRequired.Location = new System.Drawing.Point(171, 0);
+			this.labelKeyModifiersAreRequired.Name = "labelKeyModifiersAreRequired";
+			this.labelKeyModifiersAreRequired.Size = new System.Drawing.Size(189, 25);
+			this.labelKeyModifiersAreRequired.TabIndex = 28;
+			this.labelKeyModifiersAreRequired.Text = "REQUIRED";
+			this.labelKeyModifiersAreRequired.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
+			// SettingsForm
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.ClientSize = new System.Drawing.Size(439, 386);
+			this.Controls.Add(this.groupBox2);
+			this.Controls.Add(this.groupBox1);
+			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+			this.MaximizeBox = false;
+			this.MinimizeBox = false;
+			this.Name = "SettingsForm";
+			this.Text = "Settings";
+			this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.SettingsForm_FormClosing);
+			this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.SettingsForm_FormClosed);
+			this.Load += new System.EventHandler(this.SettingsForm_Load);
+			this.Shown += new System.EventHandler(this.SettingsForm_Shown);
+			this.groupBox1.ResumeLayout(false);
+			this.groupBox1.PerformLayout();
+			this.panel3.ResumeLayout(false);
+			this.panel3.PerformLayout();
+			this.panel2.ResumeLayout(false);
+			this.panel2.PerformLayout();
+			this.panel1.ResumeLayout(false);
+			this.panel1.PerformLayout();
+			this.groupBox2.ResumeLayout(false);
+			this.groupBox2.PerformLayout();
+			this.ResumeLayout(false);
 
         }
 
@@ -528,10 +507,11 @@ namespace WindowsVirtualDesktopHelper {
 		private System.Windows.Forms.CheckBox checkBoxShowDesktopNameInitial;
 		private System.Windows.Forms.CheckBox checkBoxOverlayShowOnAllMonitors;
 		private System.Windows.Forms.Panel panel3;
-		private System.Windows.Forms.RadioButton radioButtonUseHotKeysToJumpToDesktopAlt;
-		private System.Windows.Forms.RadioButton radioButtonUseHotKeysToJumpToDesktopAltShift;
-		private System.Windows.Forms.RadioButton radioButtonUseHotKeysToJumpToDesktopCtrlAlt;
-		private System.Windows.Forms.RadioButton radioButtonUseHotKeysToJumpToDesktopCtrl;
 		private System.Windows.Forms.CheckBox checkBoxUseHotKeysToJumpToDesktop;
+		private System.Windows.Forms.CheckBox checkBoxUseHotKeysToJumpToDesktopCtrl;
+		private System.Windows.Forms.CheckBox checkBoxUseHotKeysToJumpToDesktopAlt;
+		private System.Windows.Forms.CheckBox checkBoxUseHotKeysToJumpToDesktopShift;
+		private System.Windows.Forms.CheckBox checkBoxUseHotKeysToJumpToDesktopWin;
+		private System.Windows.Forms.Label labelKeyModifiersAreRequired;
 	}
 }

--- a/Source/Forms/SettingsForm.cs
+++ b/Source/Forms/SettingsForm.cs
@@ -16,11 +16,8 @@ namespace WindowsVirtualDesktopHelper {
 			InitializeComponent();
 			LoadSettingsIntoUI();
 
-
 			IsLoading = false;
 		}
-
-		
 
 		private void LoadSettingsIntoUI() {
 
@@ -48,20 +45,26 @@ namespace WindowsVirtualDesktopHelper {
 			this.radioButtonPositionBottomLeft.Checked = Settings.GetString("feature.showDesktopSwitchOverlay.position") == "bottomleft";
 			this.radioButtonPositionBottomCenter.Checked = Settings.GetString("feature.showDesktopSwitchOverlay.position") == "bottomcenter";
 			this.radioButtonPositionBottomRight.Checked = Settings.GetString("feature.showDesktopSwitchOverlay.position") == "bottomright";
-			this.radioButtonUseHotKeysToJumpToDesktopAlt.Checked = Settings.GetString("feature.useHotKeyToJumpToDesktopNumber.hotkey") == "Alt";
-			this.radioButtonUseHotKeysToJumpToDesktopAltShift.Checked = Settings.GetString("feature.useHotKeyToJumpToDesktopNumber.hotkey") == "Alt + Shift";
-			this.radioButtonUseHotKeysToJumpToDesktopCtrl.Checked = Settings.GetString("feature.useHotKeyToJumpToDesktopNumber.hotkey") == "Ctrl";
-			this.radioButtonUseHotKeysToJumpToDesktopCtrlAlt.Checked = Settings.GetString("feature.useHotKeyToJumpToDesktopNumber.hotkey") == "Ctrl + Alt";
 
-			checkBoxShowOverlay_CheckedChanged(this, null);
-			checkBoxUseHotKeysToJumpToDesktop_CheckedChanged(this, null);
+			if (this.checkBoxUseHotKeysToJumpToDesktop.Checked) {
+				string keyModifierSetting = Settings.GetString("feature.useHotKeyToJumpToDesktopNumber.hotkey").Replace(" + ", ", ");
+				if (KeyModifiers.TryParse(keyModifierSetting, true, out KeyModifiers keyModifiers)) {
+
+					this.checkBoxUseHotKeysToJumpToDesktopCtrl.Checked = keyModifiers.HasFlag(KeyModifiers.Ctrl);
+					this.checkBoxUseHotKeysToJumpToDesktopAlt.Checked = keyModifiers.HasFlag(KeyModifiers.Alt);
+					this.checkBoxUseHotKeysToJumpToDesktopShift.Checked = keyModifiers.HasFlag(KeyModifiers.Shift);
+					this.checkBoxUseHotKeysToJumpToDesktopWin.Checked = keyModifiers.HasFlag(KeyModifiers.Win);
+				}
+			}
+
+			EnableDisableModifierCheckboxes(checkBoxUseHotKeysToJumpToDesktop.Checked);
+			ValidateHotkeys();
 		}
-		
+
 		private void SaveSettingsFromUI() {
 			// Save user settings to storage
 			Settings.SaveConfig();
 		}
-
 
 		#region Form Events
 
@@ -78,23 +81,21 @@ namespace WindowsVirtualDesktopHelper {
 		}
 
 		private void SettingsForm_FormClosing(object sender, FormClosingEventArgs e) {
-
 			if(e.CloseReason == CloseReason.UserClosing) {
 				e.Cancel = true;
+
+				var useHotkeys = this.checkBoxUseHotKeysToJumpToDesktop.Checked && ValidateHotkeys();
+				Settings.SetBool("feature.useHotKeyToJumpToDesktopNumber", useHotkeys);
 				SaveSettingsFromUI();
+				if (useHotkeys || !this.checkBoxUseHotKeysToJumpToDesktop.Checked) App.Instance.SetupHotKeys();
+
 				Hide();
 			}
-			
-				
 		}
 
 		#endregion
 
-
-
-
 		#region Settings UI Events
-
 
 		private void checkBoxStartupWithWindows_CheckedChanged(object sender, EventArgs e) {
 			if(IsLoading) return;
@@ -151,50 +152,67 @@ namespace WindowsVirtualDesktopHelper {
 			radioButtonPositionBottomLeft.Enabled = checkBoxShowOverlay.Checked;
 			radioButtonPositionBottomCenter.Enabled = checkBoxShowOverlay.Checked;
 			radioButtonPositionBottomRight.Enabled = checkBoxShowOverlay.Checked;
+		}
 
+		private void EnableDisableModifierCheckboxes(bool enable) {
+			checkBoxUseHotKeysToJumpToDesktopCtrl.Enabled = enable;
+			checkBoxUseHotKeysToJumpToDesktopAlt.Enabled = enable;
+			checkBoxUseHotKeysToJumpToDesktopShift.Enabled = enable;
+			checkBoxUseHotKeysToJumpToDesktopWin.Enabled = enable;
+		}
+
+		private bool ValidateHotkeys() {
+			if (checkBoxUseHotKeysToJumpToDesktop.Checked) {
+				KeyModifiers keyModifiers = KeyModifiers.None;
+
+				if (checkBoxUseHotKeysToJumpToDesktopCtrl.Checked) keyModifiers |= KeyModifiers.Ctrl;
+				if (checkBoxUseHotKeysToJumpToDesktopAlt.Checked) keyModifiers |= KeyModifiers.Alt;
+				if (checkBoxUseHotKeysToJumpToDesktopShift.Checked) keyModifiers |= KeyModifiers.Shift;
+				if (checkBoxUseHotKeysToJumpToDesktopWin.Checked) keyModifiers |= KeyModifiers.Win;
+
+				if (keyModifiers == KeyModifiers.None) {
+					labelKeyModifiersAreRequired.Text = "REQUIRED";
+					labelKeyModifiersAreRequired.Visible = true;
+				} else if (keyModifiers == KeyModifiers.Shift) {
+					labelKeyModifiersAreRequired.Text = "NOT RECOMMENDED";
+					labelKeyModifiersAreRequired.Visible = true;
+				} else labelKeyModifiersAreRequired.Visible = false;
+				
+				return keyModifiers != KeyModifiers.None;
+			}
+			
+			labelKeyModifiersAreRequired.Visible = false;
+			return true;
+		}
+
+		private KeyModifiers GetHotkeys() {
+			if (!checkBoxUseHotKeysToJumpToDesktop.Checked) return KeyModifiers.None;
+
+			KeyModifiers keyModifiers = KeyModifiers.None;
+			if (checkBoxUseHotKeysToJumpToDesktopCtrl.Checked) keyModifiers |= KeyModifiers.Ctrl;
+			if (checkBoxUseHotKeysToJumpToDesktopAlt.Checked) keyModifiers |= KeyModifiers.Alt;
+			if (checkBoxUseHotKeysToJumpToDesktopShift.Checked) keyModifiers |= KeyModifiers.Shift;
+			if (checkBoxUseHotKeysToJumpToDesktopWin.Checked) keyModifiers |= KeyModifiers.Win;
+			return keyModifiers;
 		}
 
 		private void checkBoxUseHotKeysToJumpToDesktop_CheckedChanged(object sender, EventArgs e) {
 			if(IsLoading) return;
 			Settings.SetBool("feature.useHotKeyToJumpToDesktopNumber", this.checkBoxUseHotKeysToJumpToDesktop.Checked);
+			EnableDisableModifierCheckboxes(checkBoxUseHotKeysToJumpToDesktop.Checked);
 
-			radioButtonUseHotKeysToJumpToDesktopAlt.Enabled = checkBoxUseHotKeysToJumpToDesktop.Checked;
-			radioButtonUseHotKeysToJumpToDesktopAltShift.Enabled = checkBoxUseHotKeysToJumpToDesktop.Checked;
-			radioButtonUseHotKeysToJumpToDesktopCtrl.Enabled = checkBoxUseHotKeysToJumpToDesktop.Checked;
-			radioButtonUseHotKeysToJumpToDesktopCtrlAlt.Enabled = checkBoxUseHotKeysToJumpToDesktop.Checked;
-
-			App.Instance.SetupHotKeys();
+			ValidateHotkeys();
 		}
 
-		private void radioButtonUseHotKeysToJumpToDesktopAlt_CheckedChanged(object sender, EventArgs e) {
-			if(IsLoading) return;
-			if((sender as RadioButton).Checked == true) {
-				Settings.SetString("feature.useHotKeyToJumpToDesktopNumber.hotkey", "Alt");
-				App.Instance.SetupHotKeys();
-			}
-		}
+		private void checkBoxUseHotKeysToJumpToDesktopModifier_CheckedChanged(object sender, EventArgs e) {
+			if (IsLoading) return;
 
-		private void radioButtonUseHotKeysToJumpToDesktopCtrl_CheckedChanged(object sender, EventArgs e) {
-			if(IsLoading) return;
-			if((sender as RadioButton).Checked == true) {
-				Settings.SetString("feature.useHotKeyToJumpToDesktopNumber.hotkey", "Ctrl");
-				App.Instance.SetupHotKeys();
-			}
-		}
-
-		private void radioButtonUseHotKeysToJumpToDesktopCtrlAlt_CheckedChanged(object sender, EventArgs e) {
-			if(IsLoading) return;
-			if((sender as RadioButton).Checked == true) {
-				Settings.SetString("feature.useHotKeyToJumpToDesktopNumber.hotkey", "Ctrl + Alt");
-				App.Instance.SetupHotKeys();
-			}
-		}
-
-		private void radioButtonUseHotKeysToJumpToDesktopAltShift_CheckedChanged(object sender, EventArgs e) {
-			if(IsLoading) return;
-			if((sender as RadioButton).Checked == true) {
-				Settings.SetString("feature.useHotKeyToJumpToDesktopNumber.hotkey", "Alt + Shift");
-				App.Instance.SetupHotKeys();
+			if (ValidateHotkeys()) {
+				KeyModifiers keyModifiers = GetHotkeys();
+				Settings.SetString("feature.useHotKeyToJumpToDesktopNumber.hotkey", keyModifiers.ToString().Replace(", ", " + "));
+			} else {
+				Settings.SetBool("feature.useHotKeyToJumpToDesktopNumber", false);
+				Settings.SetString("feature.useHotKeyToJumpToDesktopNumber.hotkey", "None");
 			}
 		}
 
@@ -300,5 +318,17 @@ namespace WindowsVirtualDesktopHelper {
 		}
 
 		#endregion
+
+		// Define a new KeyModifiers - don't use ModifierKeys in KeyboardHook.cs because:
+		// 1. It conflicts with the WinForms ModifierKeys property
+		// 2. This enum defines the keys in a different order that are IMHO more natural, and are used in this order when writing out to the config file
+		[Flags]
+		enum KeyModifiers {
+			None = 0,
+			Ctrl = 1,
+			Alt = 2,
+			Shift = 4,
+			Win = 8
+		}
 	}
 }

--- a/Source/Forms/SettingsForm.cs
+++ b/Source/Forms/SettingsForm.cs
@@ -173,7 +173,7 @@ namespace WindowsVirtualDesktopHelper {
 				if (keyModifiers == KeyModifiers.None) {
 					labelKeyModifiersAreRequired.Text = "REQUIRED";
 					labelKeyModifiersAreRequired.Visible = true;
-				} else if (keyModifiers == KeyModifiers.Shift) {
+				} else if (keyModifiers == KeyModifiers.Shift || keyModifiers == KeyModifiers.Win) {
 					labelKeyModifiersAreRequired.Text = "NOT RECOMMENDED";
 					labelKeyModifiersAreRequired.Visible = true;
 				} else labelKeyModifiersAreRequired.Visible = false;


### PR DESCRIPTION
Previously there was no UI ability to set the Win key as part of the "Jump to Desktop" hotkeys.  This PR adds that ability.  To avoid complicating the list of combinations, the radio buttons are converted to checkboxes, one each for Ctrl, Alt, Shift, and Win.  UI Feedback is provided to the user when they have selected to use this feature but do not have modifiers selected, as well as when the modifiers selected are not recommended (i.e. selecting just Shift or just Win).  In addition, registration errors are caught and displayed.  The configuration file format is unchanged.