### PR TITLE
Fix orphaned, unclosable AppForm host window appearing intermittently

### DIFF
--- a/Source/Forms/AppForm.cs
+++ b/Source/Forms/AppForm.cs
@@ -7,6 +7,7 @@ using WindowsVirtualDesktopHelper.WindowsHotKeyAPI;
 namespace WindowsVirtualDesktopHelper {
 	public partial class AppForm : Form {
 
+		private bool _startupDone = false;
 
 		public AppForm() {
 			// Init UI
@@ -32,7 +33,28 @@ namespace WindowsVirtualDesktopHelper {
 			}
 		}
 
-		private void AppForm_Load(object sender, EventArgs e) {
+		// This form is only a host for the tray icons and the UI message pump; it must
+		// NEVER be visible. The previous approach (WindowState=Minimized + layered styles)
+		// did not actually prevent display: Windows could restore and repaint it on events
+		// like session unlock, DPI/display changes, or an Explorer/taskbar restart, leaving a
+		// stray "Windows Virtual Desktop Manager" dialog with no close button (ControlBox=false).
+		// Overriding SetVisibleCore guarantees the window can never be shown, while still
+		// creating its handle so Invoke(), the message pump, and the NotifyIcons keep working.
+		protected override void SetVisibleCore(bool value) {
+			if (!this.IsHandleCreated) this.CreateHandle(); // ensure handle for Invoke/pump/tray
+			base.SetVisibleCore(false);                     // but never actually show it
+		}
+
+		// Because the form is never shown, the Load event no longer fires, so the startup
+		// wiring that used to live in AppForm_Load now runs here, once the handle exists.
+		protected override void OnHandleCreated(EventArgs e) {
+			base.OnHandleCreated(e);
+			if (_startupDone) return;
+			_startupDone = true;
+			StartUp();
+		}
+
+		private void StartUp() {
 			App.Instance.ShowSplash();
 			App.Instance.MonitorVDSwitch();
 			App.Instance.MonitorSystemThemeSwitch();
@@ -41,6 +63,10 @@ namespace WindowsVirtualDesktopHelper {
 			App.Instance.MonitorFocusedWindow();
 
 			App.Instance.UIUpdate();
+		}
+
+		private void AppForm_Load(object sender, EventArgs e) {
+			// Intentionally empty: startup now runs from OnHandleCreated (see SetVisibleCore).
 		}
 
 		private void AppForm_Shown(object sender, EventArgs e) {


### PR DESCRIPTION
## Problem

`AppForm` is only a host for the tray icons and the WinForms UI message pump — it's meant to stay invisible. It currently relies on `WindowState = Minimized` plus layered window styles (`WS_EX_LAYERED | WS_EX_TRANSPARENT | WS_EX_NOACTIVATE`) to stay hidden.

Neither of those actually *prevents* the window from being displayed. Windows can restore and repaint a minimized form on a number of events — session lock/unlock, RDP reconnect, DPI/display configuration changes, or an Explorer/taskbar restart. When that happens the user is left staring at a small grey **"Windows Virtual Desktop Manager"** dialog that, because `ControlBox = false`, has **no close/minimize button** and isn't in the taskbar — an orphaned, unclosable window. The only way to get rid of it is to kill the process.

This has been reported as a "weird window that sometimes appears." It is *not* the desktop-switch overlay (`SwitchNotificationForm`) — it's the host form itself leaking into view.

## Fix

Override `SetVisibleCore` so the form can **never** become visible, while still creating its window handle so `Invoke()`, the message pump, and the `NotifyIcon`s keep working. This is the canonical pattern for a hidden tray/host form and is robust against every restore trigger, instead of merely starting minimized.

Because the form is now never shown, its `Load` event no longer fires, so the startup wiring (the `Monitor*` threads, splash, initial UI update) moves from `AppForm_Load` into `OnHandleCreated`, guarded so it runs exactly once.

## Testing

Built and run on Windows 11 (build 26200). The app starts normally — tray icons appear, desktop switching/monitoring works — and the host form can no longer be brought on-screen by minimize/restore, so the stray window no longer appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)