### PR TITLE
Fix #166: stop focus restore from fighting native desktop switching

### DIFF
--- a/Source/App/App.cs
+++ b/Source/App/App.cs
@@ -329,9 +329,12 @@ namespace WindowsVirtualDesktopHelper {
 		private void _storeLastWinFocused() {
 			IntPtr hWnd = Util.OS.GetForegroundWindow();
 			if(hWnd != IntPtr.Zero) {
-				var fgWindowName = Util.OS.GetForegroundWindowName();
 				var fgWindowType = Util.OS.GetHandleWndType(hWnd);
 				if(fgWindowType == "Shell_TrayWnd") return; // we ignore the icon tray, since this takes the focus away when we click the prev/next arrows
+				// Only remember this window for the desktop it actually lives on. A native desktop
+				// switch mid-poll can otherwise file a window under the wrong desktop number, and
+				// restoring it later yanks focus back to that other desktop (see issue #166).
+				if(!Util.OS.IsWindowOnCurrentVirtualDesktop(hWnd)) return;
 				var displayNumber = (int)this.GetVDDisplayNumber(false);
 				if(VDDToLastFocusedWin.ContainsKey(displayNumber)) {
 					VDDToLastFocusedWin[displayNumber] = hWnd;
@@ -346,7 +349,9 @@ namespace WindowsVirtualDesktopHelper {
 			var displayNumber = (int)this.GetVDDisplayNumber(false);
 			if(VDDToLastFocusedWin.ContainsKey(displayNumber)) {
 				IntPtr lastWindowHandle = VDDToLastFocusedWin[displayNumber];
-				if(Util.OS.IsWindow(lastWindowHandle)) {
+				// Never yank focus to a window that isn't on the desktop we just landed on:
+				// doing so makes Windows jump back to that window's desktop (see issue #166).
+				if(Util.OS.IsWindow(lastWindowHandle) && Util.OS.IsWindowOnCurrentVirtualDesktop(lastWindowHandle)) {
 					Util.OS.SetForegroundWindow(lastWindowHandle);
 					//Console.WriteLine("restore: "+ displayNumber + " "+ lastWindowHandle);
 				}

--- a/Source/Util/OS.cs
+++ b/Source/Util/OS.cs
@@ -112,6 +112,42 @@ namespace WindowsVirtualDesktopHelper.Util {
 
 		#endregion
 
+		#region Virtual Desktop (public shell API, version-independent)
+
+		// The public IVirtualDesktopManager shell COM interface is stable across all
+		// Windows 10 (1607+) and Windows 11 builds, unlike the private per-version
+		// interfaces the app uses for switching. We only need it to answer "is this
+		// window on the currently-displayed desktop?" so we never force-focus a window
+		// that lives elsewhere (which would drag the user to that desktop, issue #166).
+		private static readonly Guid CLSID_VirtualDesktopManager = new Guid("AA509086-5CA9-4C25-8F95-589D3C07B48A");
+
+		[ComImport]
+		[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+		[Guid("A5CD92FF-29BE-454C-8D04-D82879FB3F1B")]
+		private interface IVirtualDesktopManager {
+			bool IsWindowOnCurrentVirtualDesktop(IntPtr topLevelWindow);
+			Guid GetWindowDesktopId(IntPtr topLevelWindow);
+			void MoveWindowToDesktop(IntPtr topLevelWindow, ref Guid desktopId);
+		}
+
+		private static IVirtualDesktopManager _vdManager;
+
+		// True only if hWnd is on the currently-displayed virtual desktop. Fail-closed:
+		// on any COM/handle error we return false, so callers never force-focus a window
+		// we cannot confirm lives on the current desktop (see issue #166).
+		public static bool IsWindowOnCurrentVirtualDesktop(IntPtr hWnd) {
+			try {
+				if (_vdManager == null) {
+					_vdManager = (IVirtualDesktopManager)Activator.CreateInstance(Type.GetTypeFromCLSID(CLSID_VirtualDesktopManager));
+				}
+				return _vdManager.IsWindowOnCurrentVirtualDesktop(hWnd);
+			} catch {
+				return false;
+			}
+		}
+
+		#endregion
+
 		#region Invoking Windows Features
 
 		public static void OpenTaskView() {


### PR DESCRIPTION
Fixes the focus "fighting" from #166, specifically the mechanism identified in [this comment](https://github.com/dankrusi/WindowsVirtualDesktopHelper/issues/166#issuecomment-4642232962): switching desktops natively snaps back to the previous desktop and refocuses the wrong window.

## Root cause

With `feature.restorePreviousWindowFocus` enabled, every detected switch runs `App._restorePrevWinFocus()`, which `SetForegroundWindow()`s the window recorded for the desktop just landed on. That record comes from `_storeLastWinFocused()`, polled every 200 ms:

```csharp
IntPtr hWnd = GetForegroundWindow();           // (A) reads window
...
var displayNumber = GetVDDisplayNumber(false); // (B) reads desktop number
VDDToLastFocusedWin[displayNumber] = hWnd;      // files A under B
```

`(A)` and `(B)` are read non-atomically, so during a native switch animation a window that lives on desktop 1 gets filed under desktop 2. Restoring it later force-focuses a window on another desktop, and **Windows jumps to that desktop to show it** — the snap-back. Rapid switches poison the map heavily, producing the erratic multi-hop behavior also reported.

## Fix

Guard both sides with the **public** `IVirtualDesktopManager::IsWindowOnCurrentVirtualDesktop`:

- **Store:** only record a window under the desktop it actually lives on (no more poisoning).
- **Restore:** only `SetForegroundWindow` if the recorded window is still on the desktop just landed on (no snap-back even if a stale record slips through).

The public `IVirtualDesktopManager` (CLSID `AA509086-…`, IID `A5CD92FF-…`) is stable across all Win10 1607+/Win11 builds — important because affected users fall back to `VirtualDesktopWin11_23H2_2921`, which has no per-version manager. It's added once in `Util.OS` (fail-closed on any COM error), so the 9 version-specific implementations, the app's `IVirtualDesktopManager` interface, and the default settings are all untouched.

## Scope

This addresses the focus-restoration fighting. The feature is **off by default**, so the separate "fighting on stock config" reports (feature disabled ⇒ no `SetForegroundWindow` on the switch path at all) are a different, Windows-level cause (wallpaper/accent-color repaint, stale post-sleep COM) and are out of scope here.

## Testing

- Builds clean (VS 2026 MSBuild, .NET Framework 4.7.2).
- Reproduced the comment's scenario with the feature enabled (two desktops, two apps each, different focus per desktop): before → snaps back to the origin desktop; after → stays on the target desktop with its own last-focused window. Rapid switching no longer multi-hops.
- Ran ~1 hour of normal daily use with `restorePreviousWindowFocus` on — no snap-back observed.

No automated test: the path is COM- and live-desktop-bound and the repo has no test project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)